### PR TITLE
release: v1.9.8 - update contributors

### DIFF
--- a/content/announcements/_index.md
+++ b/content/announcements/_index.md
@@ -1,12 +1,12 @@
 ---
 title: 'A better knowledge base'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledge'
+description: 'We provide the means for the collection, organization and computerized retrieval of knowledge'
 headerTheme: light
 url: 'announcements'
 heroBg: "/images/hero.jpg"
 latestVer: true
 ---
 
-{{% content "announcements/v1.9/v1.9.7.md" %}}
+{{% content "announcements/v1.9/v1.9.9.md" %}}
 
 {{% button href="/announcements/older-versions/"  position="center" text-transform="" class="btn-gradient" margin="0px 0px 30px"  %}}See Older Versions{{% /button %}}

--- a/content/announcements/v1.9/_index.md
+++ b/content/announcements/v1.9/_index.md
@@ -1,0 +1,13 @@
+---
+title: 'Fluent Bit v1.9 Series'
+description: "[Fluent Bit v1.9](https://github.com/fluent/fluent-bit/tree/1.9) is the new **stable branch** for production usage. Based on bug reports or specific minor feature requests, we do quick releases upon demand. Below is a list of the notes for each version."
+url: "/announcements/v1.9/"
+herobg: "/images/hero@2x.jpg"
+latestVer: true
+releaseNotes:
+  heading: "Release Notes v1.9.9"
+  version: "v1.9.9"
+  text: "Fluent Bit is a Fast and Lightweight Data Processor and Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.9.9. <br>
+  For people upgrading from previous versions you must read the Upgrading Notes section of our documentation:
+  https://docs.fluentbit.io/manual/installation/upgrade_notes"
+---

--- a/content/announcements/v1.9/v1.9.7.md
+++ b/content/announcements/v1.9/v1.9.7.md
@@ -1,43 +1,36 @@
 ---
-title: 'v1.9.8'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
-url: "/announcements/v1.9.8/"
-release_date: 2022-09-06
-publishdate: 2022-09-06
-ver: v1.9.8
+title: 'v1.9.7'
+description: 'We provide the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
+url: "/announcements/v1.9.7/"
+release_date: 2022-07-07
+publishdate: 2022-07-07
+ver: v1.9.7
 herobg: "/images/hero@2x.jpg"
 latestVer: true
 ---
 
 ###### KNOWLEDGE BASE
 
-### Release Notes v1.9.8
+### Release Notes v1.9.7
 
-[Fluent Bit](https://fluentbit.io) is a Fast and Lightweight Data Processor and Forwarder for Linux, BSD and OSX. We are proud to announce the availability of **Fluent Bit v1.9.8**.
+[Fluent Bit](https://fluentbit.io) is a Fast and Lightweight Data Processor and Forwarder for Linux, BSD and OSX. We are proud to announce the availability of **Fluent Bit v1.9.7**.
 
 #### Changes
 
  - __Core__
-   - ra_key: save value when the data type is array (#5936)
-   - windows: enabled firehose, kinesis streams, and aws filter for Windows
-   - multiline: fix last_flush data type
-   - multiline: fix flush timeout logic (fixes #5504)
-   - pack: fix oss-fuzz crashon tokens state (#5975)
-   - pack: fix heap-double-free in flb_pack_state_reset (#5883)
-
- - __Libs__
-    - cmetrics: upgrade from v0.3.5 to v0.3.6
+   - event loop: core event kqueue: don't use NOTE_SECONDS on macOS
+   - aws_util: use concurrent safe gmtime_r
+   - aws_util: use conccurent safe strtok_r
+   - aws_util: fix leak in user agent code
+   - aws_util: set AWS Fluent Bit user agent based on environment
 
  - __Plugins__
    - [Tail (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/tail/)
-      - Add missed argument processed_bytes
-      - Fix path_key when the file is rotated (#5829)
-   - [Stackdriver (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver/)
-      - Add name label to the metrics emitted
-   - [Kinesis_Firehose (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/kinesis_firehose/)
-      - Refactoring to fix windows build
-   - [Kafka (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/kafka/)
-      - Add support to force flush when shutdown. (fluent#5593)
+      - Added event based file ingestion batch limit
+   - [S3 (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/s3/)
+      - Add gzip compression support for multipart uploads
+   - [Cloudwatch_Logs (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch_logs/)
+      - Skip counting empty events
 
 {{< contributor-list >}}
 
@@ -45,16 +38,13 @@ latestVer: true
 
 On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
-- [Alexs L](https://github.com/sashashura)
-- [Eduardo Silva](https://github.com/edsiper)
-- [frd](https://github.com/frd)
-- [Takahiro Yamashita](https://github.com/nokute78)
-- jinyong.choi
-- Alexander Shadchin
-- [Ridwan Sharif](https://github.com/ridwanmsharif)
+- [Leonardo Alminana](https://github.com/leonardo-albertovich)
 - [Hiroshi Hatake](https://github.com/cosmo0920)
-- [Thiago Padilha](https://github.com/tarruda)
-- [Harsh Rawat](https://github.com/harsh-rawat)
+- [Wesley Pettit](https://github.com/PettitWesley)
+- [Zhonghui Hu](https://github.com/zhonghui12)
+- Weijian Zhang
+- Andy Wang
+- [Eduardo Silva](https://github.com/edsiper)
 
 {{< /contributor-list >}}
 

--- a/content/announcements/v1.9/v1.9.8.md
+++ b/content/announcements/v1.9/v1.9.8.md
@@ -1,10 +1,10 @@
 ---
 title: 'v1.9.8'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
+description: 'We provide the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
 url: "/announcements/v1.9.8/"
-release_date: 2022-07-07
-publishdate: 2022-07-07
-ver: v1.9.7
+release_date: 2022-09-06
+publishdate: 2022-09-06
+ver: v1.9.8
 herobg: "/images/hero@2x.jpg"
 latestVer: true
 ---
@@ -13,24 +13,31 @@ latestVer: true
 
 ### Release Notes v1.9.8
 
-[Fluent Bit](https://fluentbit.io) is a Fast and Lightweight Data Processor and Forwarder for Linux, BSD and OSX. We are proud to announce the availability of **Fluent Bit v1.9.7**.
+[Fluent Bit](https://fluentbit.io) is a Fast and Lightweight Data Processor and Forwarder for Linux, BSD and OSX. We are proud to announce the availability of **Fluent Bit v1.9.8**.
 
 #### Changes
 
  - __Core__
-   - event loop: core event kqueue: don't use NOTE_SECONDS on macOS
-   - aws_util: use concurrent safe gmtime_r
-   - aws_util: use conccurent safe strtok_r
-   - aws_util: fix leak in user agent code
-   - aws_util: set AWS Fluent Bit user agent based on environment
+   - ra_key: save value when the data type is array (#5936)
+   - windows: enabled firehose, kinesis streams, and aws filter for Windows
+   - multiline: fix last_flush data type
+   - multiline: fix flush timeout logic (fixes #5504)
+   - pack: fix oss-fuzz crashon tokens state (#5975)
+   - pack: fix heap-double-free in flb_pack_state_reset (#5883)
+
+ - __Libs__
+    - cmetrics: upgrade from v0.3.5 to v0.3.6
 
  - __Plugins__
    - [Tail (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/tail/)
-      - Added event based file ingestion batch limit
-   - [S3 (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/s3/)
-      - Add gzip compression support for multipart uploads
-   - [Cloudwatch_Logs (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch_logs/)
-      - Skip counting empty events
+      - Add missed argument processed_bytes
+      - Fix path_key when the file is rotated (#5829)
+   - [Stackdriver (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver/)
+      - Add name label to the metrics emitted
+   - [Kinesis_Firehose (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/kinesis_firehose/)
+      - Refactoring to fix windows build
+   - [Kafka (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/kafka/)
+      - Add support to force flush when shutdown. (fluent#5593)
 
 {{< contributor-list >}}
 
@@ -38,13 +45,16 @@ latestVer: true
 
 On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
-- [Leonardo Alminana](https://github.com/leonardo-albertovich)
-- [Hiroshi Hatake](https://github.com/cosmo0920)
-- [Wesley Pettit](https://github.com/PettitWesley)
-- [Zhonghui Hu](https://github.com/zhonghui12)
-- Weijian Zhang
-- Andy Wang
+- [Alexs L](https://github.com/sashashura)
 - [Eduardo Silva](https://github.com/edsiper)
+- [François-Régis Deboffles](https://github.com/frdeboffles)
+- [Takahiro Yamashita](https://github.com/nokute78)
+- jinyong.choi
+- Alexander Shadchin
+- [Ridwan Sharif](https://github.com/ridwanmsharif)
+- [Hiroshi Hatake](https://github.com/cosmo0920)
+- [Thiago Padilha](https://github.com/tarruda)
+- [Harsh Rawat](https://github.com/harsh-rawat)
 
 {{< /contributor-list >}}
 

--- a/content/announcements/v1.9/v1.9.9.md
+++ b/content/announcements/v1.9/v1.9.9.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.9.9'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
+description: 'We provide the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
 url: "/announcements/v1.9.9/"
 release_date: 2022-09-29
 publishdate: 2022-09-29

--- a/layouts/partials/lastest-version.html
+++ b/layouts/partials/lastest-version.html
@@ -4,7 +4,7 @@
 <section class='section latest-ver {{if ne .RelPermalink "/documentation/" }} {{if $data.light}}light{{end}} {{end}}'>
     <div class="container">
         <div class="row d-none d-md-block">
-            <div class="col"><h4>Lastest Version</h4></div>
+            <div class="col"><h4>Latest Version</h4></div>
         </div>
         <div class="row ">
             <div class="col">


### PR DESCRIPTION
I updated the contributions from `frd` to use my name and the right link to my github account (my bad authoring my commit using my company's user info).
I also swapped the `v1.9.7.md` and `v1.9.8.md` files since 1.9.8 content was in `v1.9.7.md` and vice versa.