### PR TITLE
Add blog author and date

### DIFF
--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -319,6 +319,10 @@ header{
     color: $white;
     mix-blend-mode: normal;
   }
+    p{
+  	font-style:normal;
+  	color:$white;
+  	}
 }
 
 .brand-list{

--- a/content/posts/_index.md
+++ b/content/posts/_index.md
@@ -1,7 +1,7 @@
 ---
 title: 'News & insights'
 description: 'Explore the latest news from Fluent Bit. <br> Research analysis, and perspectives for our latest projects'
-date: 2021-02-10
+# date: 2021-02-10
 url: 'blog'
 herobg: "/images/hero@2x.jpg"
 

--- a/layouts/partials/hero-inner.html
+++ b/layouts/partials/hero-inner.html
@@ -4,9 +4,13 @@
             <div class="col-sm-12 col-md-7">
                 <h1  style='{{if eq .Page.RelPermalink "/documentation/" }}width: 87%; {{end}}{{if eq .Page.RelPermalink "/blog/"  }}width: 76%; {{end}}'>{{ .Title | safeHTML  }}</h1>            
                 <h6>{{.Params.description | safeHTML}}</h6>
+                {{ if isset .Params "author" }}
                 <p>Written by {{.Params.author | safeHTML}}</p>
+                {{ end }}
+                {{ if isset .Params "date" }}
                 {{ $dateFormat := default "January 2, 2006" (index .Site.Params "date_format") }}
-                <p>{{ .Date.Format $dateFormat }}
+                <p>{{ .Date.Format $dateFormat }}</p>
+                {{ end }}
             </div>
         </div>
     </div>

--- a/layouts/partials/hero-inner.html
+++ b/layouts/partials/hero-inner.html
@@ -1,10 +1,12 @@
-
 <section class="hero hero-inner" style="background-image: url({{.Params.heroBg}});">
     <div class="container">
         <div class="row">
             <div class="col-sm-12 col-md-7">
                 <h1  style='{{if eq .Page.RelPermalink "/documentation/" }}width: 87%; {{end}}{{if eq .Page.RelPermalink "/blog/"  }}width: 76%; {{end}}'>{{ .Title | safeHTML  }}</h1>            
                 <h6>{{.Params.description | safeHTML}}</h6>
+                <p>Written by {{.Params.author | safeHTML}}</p>
+                {{ $dateFormat := default "January 2, 2006" (index .Site.Params "date_format") }}
+                <p>{{ .Date.Format $dateFormat }}
             </div>
         </div>
     </div>


### PR DESCRIPTION
* updated hero-inner.html to pull in author and date from post front matter
* added css style to present <p> content in white while within the hero-inner class.


Signed-off-by: Erik Bledsoe <erik@calyptia.com>