### PR TITLE
Add security policy and EOL info to older-versions

### DIFF
--- a/content/announcements/older-versions.md
+++ b/content/announcements/older-versions.md
@@ -2,6 +2,9 @@
 title: 'Older Versions'
 description: |
  All versions are neatly organized to make it easy to find what you are looking for.
+
+ Security Policy: support for current series ends three months after a new series is released.
+
 headerTheme: light
 permalink: '/announcements/older-versions'
 heroBg: "/images/hero.jpg"

--- a/content/announcements/v1.8/_index.md
+++ b/content/announcements/v1.8/_index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Fluent Bit v1.8 Series'
+title: 'Fluent Bit v1.8 Series (EOL Dec 5, 2022)'
 description: "[Fluent Bit v1.8](https://github.com/fluent/fluent-bit/tree/1.8) is the new **stable branch** for production usage. Based on bug reports or specific minor feature requests, we do quick releases upon demand. Below is a list of the notes for each version."
 url: "/announcements/v1.8/"
 herobg: "/images/hero@2x.jpg"

--- a/content/announcements/v1.9/_index.md
+++ b/content/announcements/v1.9/_index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Fluent Bit v1.9 Series'
+title: 'Fluent Bit v1.9 Series (EOL Dec 5, 2022)'
 description: "[Fluent Bit v1.9](https://github.com/fluent/fluent-bit/tree/1.9) is the new **stable branch** for production usage. Based on bug reports or specific minor feature requests, we do quick releases upon demand. Below is a list of the notes for each version."
 url: "/announcements/v1.9/"
 herobg: "/images/hero@2x.jpg"

--- a/content/announcements/v2.0/_index.md
+++ b/content/announcements/v2.0/_index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Fluent Bit v2.0 Series'
+title: 'Fluent Bit v2.0 Series (EOL Jul 19, 2023)'
 description: "[Fluent Bit v1.9](https://github.com/fluent/fluent-bit/tree/2.0) is the new **stable branch** for production usage. Based on bug reports or 
 specific minor feature requests, we do quick releases upon demand. Below is a list of the notes for each version."
 url: "/announcements/v2.0/"

--- a/content/announcements/v2.1/_index.md
+++ b/content/announcements/v2.1/_index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Fluent Bit v2.1 Series'
+title: 'Fluent Bit v2.1 Series (EOL Feb 6, 2024)'
 description: "[Fluent Bit v1.9](https://github.com/fluent/fluent-bit/tree/2.0) is the new **stable branch** for production usage. Based on bug reports or 
 specific minor feature requests, we do quick releases upon demand. Below is a list of the notes for each version."
 url: "/announcements/v2.1/"

--- a/content/announcements/v2.1/v2.1.1.md
+++ b/content/announcements/v2.1/v2.1.1.md
@@ -2,8 +2,8 @@
 title: 'v2.1.1'
 description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
 url: "/announcements/v2.1.1/"
-release_date: 2023-04-19
-publishdate: 2023-04-19
+release_date: 2023-04-20
+publishdate: 2023-04-20
 ver: v2.1.1
 herobg: "/images/hero@2x.jpg"
 latestVer: true

--- a/content/announcements/v2.1/v2.1.2.md
+++ b/content/announcements/v2.1/v2.1.2.md
@@ -2,8 +2,8 @@
 title: 'v2.1.2'
 description: 'We provide the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
 url: "/announcements/v2.1.2/"
-release_date: 2023-02-06
-publishdate: 2023-02-06
+release_date: 2023-04-26
+publishdate: 2023-04-26
 ver: v2.1.2
 herobg: "/images/hero@2x.jpg"
 latestVer: true


### PR DESCRIPTION
Reached out to agup006 (Anurag Gupta) on slack regarding security update support period for older releases and learned that security updates for older releases ends three months after a new version is released. This change updates the older versions page to reflect this policy.

Bonus: corrected release dates for v2.1.1 and v2.1.2