### PR TITLE
remove-dallas-meetup-banner

### DIFF
--- a/layouts/partials/hero.html
+++ b/layouts/partials/hero.html
@@ -27,12 +27,9 @@
 </div>
 
         <center>
-          <!-- ><a href="https://calyptia.com/on-demand-webinars" target="_blank">
+          <a href="https://calyptia.com/on-demand-webinars" target="_blank">
             <img src="/images/fluent-bit-academy-banner.png" style="max-width: 35%;" alt="New Fluent Bit Academy!: Your destination for learning all things Fluent Bit'" />
-          </a> --> 
-          <a href="https://www.meetup.com/fluent-community-meeting/events/300641080/" target="_blank">
-            <img src="/images/dallas-meetup-banner.png" style="max-width: 35%;" alt="Fluent Bit Community Meetup in Dallas'" />
-          </a>
+          </a> 
         </center>
 
 </section>


### PR DESCRIPTION
Removes the temporary Dallas community meetup banner and restores the Fluent Bit academy banner.