### PR TITLE
Remove Calyptia as Enterprise resource for web migration.

### DIFF
--- a/content/enterprise.md
+++ b/content/enterprise.md
@@ -13,7 +13,7 @@ enterprise:
   - title: Chronosphere
     description: Enterprise telemetry pipeline solution and support services from the creators of Fluent Bit and Calyptia. Recognized as a leader by major analyst firms, Chronosphere also offers a full observability platform.
     logo: /images/chronosphere-logo-vertical.png
-    buttonUrl: "https://chronosphere.io/platform/telemetry-pipeline/"
+    buttonUrl: "https://chronosphere.io/platform/telemetry-pipeline/?utm_source=fluent-bit&utm_medium=referral&utm_content=enterprise-tile"
     buttonText: "Learn more"
     tabOpen: "_blank"
   - title: ITOCHU Techno-Solutions America, Inc.

--- a/content/enterprise.md
+++ b/content/enterprise.md
@@ -10,11 +10,6 @@ enterprise:
   enabled: true
   position: 0
   list:
-  - title: Calyptia
-    description: Support services and Enterprise features from the creators and maintainers of Fluentd and Fluent Bit. Calyptia was acquired by Chronosphere in 2024.
-    logo: /images/calyptia.svg
-    buttonUrl: "https://calyptia.com/"
-    buttonText: "read More"
   - title: Chronosphere
     description: Enterprise telemetry pipeline solution and support services from the creators of Fluent Bit and Calyptia. Recognized as a leader by major analyst firms, Chronosphere also offers a full observability platform.
     logo: /images/chronosphere-logo-vertical.png


### PR DESCRIPTION
The full Calyptia site is being migrated on NOV. 2nd. this PR removes the Calyptia site as an enterprise source and standardizes on Chronosphere.