### PR TITLE
Redirected dead Fluent Bit newsletter signup button to active newsletter signup URL.

### DIFF
--- a/content/community.md
+++ b/content/community.md
@@ -24,7 +24,7 @@ community:
   - title: Newsletter
     description: Sign up to receive our newsletter for product information, Fluent Bit events, and opportunities to contribute to the project.
     logo: /images/mail.svg
-    buttonUrl: "https://www.fluentd.org/newsletter"
+    buttonUrl: "https://chronosphere.io/fluent-bit/#subscribe"
     buttonText: "Sign up"
     tabOpen: "_blank"
 meeting:


### PR DESCRIPTION
The Fluent Bit newsletter sign up button ends up here currently:

![Screenshot 2025-05-15 at 10 46 34](https://github.com/user-attachments/assets/8ab3c73e-11de-4715-81e6-fa4d028acefb)

Redirecting this button URL to current signup here:

![Screenshot 2025-05-15 at 10 47 26](https://github.com/user-attachments/assets/5ad99815-02fb-40f0-a841-cbd46b895fef)
