### PR TITLE
Fixing all plugin references as URLs were broken in v4.0.5 release blog. Fixes #101.

### DIFF
--- a/content/announcements/v4.0/v4.0.5.md
+++ b/content/announcements/v4.0/v4.0.5.md
@@ -42,9 +42,9 @@ Below is a detailed list of changes included in this release...
 
 <br>
 
-- **[Windows_exporter (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/windows_exporter)**
+- **[Windows_exporter (Input)](https://docs.fluentbit.io/manual/data-pipeline/inputs/windows-exporter-metrics)**
   - Add cache metrics ([PR #10627](https://github.com/fluent/fluent-bit/pull/10627))
-- **[Windows_exporter_metrics (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/windows_exporter_metrics)**
+- **[Windows_exporter_metrics (Input)](https://docs.fluentbit.io/manual/data-pipeline/inputs/windows-exporter-metrics)**
   - Handle Cache and System special types ([PR #10627](https://github.com/fluent/fluent-bit/pull/10627))
   - Add average queued metrics for logical_disk ([PR #10627](https://github.com/fluent/fluent-bit/pull/10627))
   - Add output_queue_length_packets for net ([PR #10627](https://github.com/fluent/fluent-bit/pull/10627))
@@ -55,9 +55,9 @@ Below is a detailed list of changes included in this release...
   - Support more metrics for CPU ([PR #10627](https://github.com/fluent/fluent-bit/pull/10627))
   - Support retrival of second values of perflib ([PR #10627](https://github.com/fluent/fluent-bit/pull/10627))
   - Add support for rtc metrics of CPU ([PR #10627](https://github.com/fluent/fluent-bit/pull/10627))
-- **[Syslog (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/syslog)**
+- **[Syslog (Input)](https://docs.fluentbit.io/manual/data-pipeline/inputs/syslog)**
   - performance: do batching to reduce ring buffer pressure under load ([PR #10636](https://github.com/fluent/fluent-bit/pull/10636))
-- **[File (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/file)**
+- **[File (Output)](https://docs.fluentbit.io/manual/data-pipeline/outputs/file)**
   - Replace SHCreateDirectoryExA to work for recursive directories correctly ([PR #10579](https://github.com/fluent/fluent-bit/pull/10579))
   - Handle drive letter properly ([PR #10579](https://github.com/fluent/fluent-bit/pull/10579))
 


### PR DESCRIPTION
Fixing all plugin references as URLs were broken in v4.0.5 release blog. Fixes #101.