### PR TITLE
Fixes for release docs plugin links for Fluent Bit v1.6 through v1.9. Part of issue #30.

### DIFF
--- a/content/announcements/v1.6/v1.6.0.md
+++ b/content/announcements/v1.6/v1.6.0.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.6.0'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.6.0.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.6.0.'
 url: "/announcements/v1.6.0/"
 herobg: "/images/hero@2x.jpg"
 release_date: 2020-10-09
@@ -18,7 +18,7 @@ latestVer: true
 
 For people upgrading from previous versions you **must read** the Upgrading Notes section of our documentation:
 
-https://docs.fluentbit.io/manual/installation/upgrade_notes
+https://docs.fluentbit.io/manual/1.6/installation/upgrade_notes
 
 #### Changes
 
@@ -39,7 +39,7 @@ The following are the most visible changes for end-users:
 
 ###### Tail Input (local files)
 
-The are three major changes on this release for Tail input plugin, it now effectively follow files from the end like `tail -f`. In previous versions it always read them from the beginning. For opened files at start, it follows from the end, for newly discovered files at runtime or after rotation, it follows the files from the beginning. If you want to use the older mechanism you can enable the new option available `read_from_head`.
+There are three major changes on this release for Tail input plugin, it now effectively follow files from the end like `tail -f`. In previous versions it always read them from the beginning. For opened files at start, it follows from the end, for newly discovered files at runtime or after rotation, it follows the files from the beginning. If you want to use the older mechanism you can enable the new option available `read_from_head`.
 
 Other performance improvements has been implemented when using the `db` option (database file). The synchronization mechanism has been changed to `normal` by default and changed the default journal mode. This is a big performance improvement for most of the users.
 
@@ -49,32 +49,32 @@ If you are a Windows user, now you can enjoy for large files support.
 
 ##### Amazon S3 & Kinesis Firehose Outputs
 
-Amazon has done a great contribution on this major release, they contributed two new plugins plus other important improvements in existent components, list of changes below:
+Amazon has done a great contribution to this major release, they contributed two new plugins plus other important improvements in existent components, list of changes below:
 
-* [New plugin for Amazon S3](https://docs.fluentbit.io/manual/v/master/pipeline/outputs/s3)
-* [New high performance core plugin for Amazon Kinesis Data Firehose](https://docs.fluentbit.io/manual/v/master/pipeline/outputs/firehose)
-* [The AWS Metadata filter now supports more types of metadata, including VPC ID](https://docs.fluentbit.io/manual/v/master/pipeline/filters/aws-metadata)
-* All AWS outputs now support custom STS endpoints, enabling you to use a VPC endpoint for STS]
+* [New plugin for Amazon S3](https://docs.fluentbit.io/manual/1.6/pipeline/outputs/s3)
+* [New high performance core plugin for Amazon Kinesis Data Firehose](https://docs.fluentbit.io/manual/1.6/pipeline/outputs/firehose)
+* [The AWS Metadata filter now supports more types of metadata, including VPC ID](https://docs.fluentbit.io/manual/1.6/pipeline/filters/aws-metadata)
+* All AWS outputs now support custom STS endpoints, enabling you to use a VPC endpoint for STS
 
 #### Microsoft Azure Blob Output
 
-In a joint work with Microsoft Azure team, we created the new Azure Blob output plugin. This connector is flexible enough to be used with `BlockBlob` or `AppendBlob` types. In addition it can be used with custom end-points, providing a default connectivity with Azure service but optionally it can be used with [Azurite Emulator](https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azurite) for local testing.
+In a joint work with Microsoft Azure team, we created the new Azure Blob output plugin. This connector is flexible enough to be used with `BlockBlob` or `AppendBlob` types. In addition, it can be used with custom end-points, providing a default connectivity with Azure service, but optionally it can be used with [Azurite Emulator](https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azurite) for local testing.
 
 ![azure_blob](/images/azure_blob.png)
 
 Learn more about this new output here:
 
-[https://docs.fluentbit.io/manual/pipeline/outputs/azure_blob](https://docs.fluentbit.io/manual/pipeline/outputs/azure_blob)
+[https://docs.fluentbit.io/manual/1.6/pipeline/outputs/azure_blob](https://docs.fluentbit.io/manual/1.6/pipeline/outputs/azure_blob)
 
 ##### TensorFlow Lite Filter
 
-The new filter [Tensorflow](https://docs.fluentbit.io/manual/pipeline/filters/tensorflow) allows running Machine Learning inference tasks on the records of data coming from input plugins or stream processor.
+The new filter [Tensorflow](https://docs.fluentbit.io/manual/1.6/pipeline/filters/tensorflow) allows running Machine Learning inference tasks on the records of data coming from input plugins or stream processor.
 
 Tensorflow Lite is a lightweight open-source deep learning framework that is used for mobile and IoT applications. Tensorflow Lite only handles inference (not training), therefore, it loads pre-trained models (.tflite files) that are converted into Tensorflow Lite format (FlatBuffer).
 
 Learn more about this new filter here:
 
-[https://docs.fluentbit.io/manual/v/master/pipeline/filters/tensorflow](https://docs.fluentbit.io/manual/v/master/pipeline/filters/tensorflow)
+[https://docs.fluentbit.io/manual/1.6/pipeline/filters/tensorflow](https://docs.fluentbit.io/manual/1.6/pipeline/filters/tensorflow)
 
 ##### Lua Filter
 
@@ -91,35 +91,35 @@ when returning the value the timestamp will not lose precision.
 
 Learn more about our Lua filter here:
 
-[https://docs.fluentbit.io/manual/v/master/pipeline/filters/lua](https://docs.fluentbit.io/manual/v/master/pipeline/filters/lua)
+[https://docs.fluentbit.io/manual/1.6/pipeline/filters/lua](https://docs.fluentbit.io/manual/1.6/pipeline/filters/lua)
 
 ##### Elasticsearch Output
 
-The [Elasticsearch Output](https://docs.fluentbit.io/manual/pipeline/outputs/es/) plugin now increases the default size of the response buffer to 512k and it supports nanosecond timestamp precision.
+The [Elasticsearch Output](https://docs.fluentbit.io/manual/1.6/pipeline/outputs/elasticsearch/) plugin now increases the default size of the response buffer to 512k, and it supports nanosecond timestamp precision.
 
 Learn more about this plugin here:
 
-[https://docs.fluentbit.io/manual/pipeline/outputs/elasticsearch](https://docs.fluentbit.io/manual/pipeline/outputs/elasticsearch)
+[https://docs.fluentbit.io/manual/1.6/pipeline/outputs/elasticsearch](https://docs.fluentbit.io/manual/1.6/pipeline/outputs/elasticsearch)
 
 ##### Kafka Output
 
 There are cases where the buffered messages ready for delivery cannot be flushed if the Kafka Broker is not fast enough, this local buffering is handled by `rdkafka`.
 
-The Kafka output connector now exposes a new configuration property called `queue_full_retries` which indicate the connector the limit of retries to enqueue the data into `rdkafka`. If the process fails by default 10 times, it issue a full retry to Fluent Bit engine.
+The Kafka output connector now exposes a new configuration property called `queue_full_retries` which indicate the connector the limit of retries to enqueue the data into `rdkafka`. If the process fails by default 10 times, it issues a full retry to Fluent Bit engine.
 
 note: setting this value to `0` is possible if you desire unlimited enqueue retries.
 
 Learn more about this plugin here:
 
-[https://docs.fluentbit.io/manual/pipeline/outputs/kafka](https://docs.fluentbit.io/manual/pipeline/outputs/kafka)
+[https://docs.fluentbit.io/manual/1.6/pipeline/outputs/kafka](https://docs.fluentbit.io/manual/1.6/pipeline/outputs/kafka)
 
 #### PostgreSQL Output
 
-Our PostreSQL output connector landed in v1.5 series and now in addition to Postres it got compatibility with CockroachDB. The new option `cockroachdb` is available in the configuration (default: off).
+Our PostgreSQL output connector landed in v1.5 series and now in addition to Postres it got compatibility with CockroachDB. The new option `cockroachdb` is available in the configuration (default: off).
 
 Learn more about this plugin here:
 
-[https://docs.fluentbit.io/manual/pipeline/outputs/postgresql](https://docs.fluentbit.io/manual/pipeline/outputs/postgresql)
+[https://docs.fluentbit.io/manual/1.6/pipeline/outputs/postgresql](https://docs.fluentbit.io/manual/1.6/pipeline/outputs/postgresql)
 
 #### Stackdriver Output
 
@@ -127,24 +127,24 @@ The new version of the Google Stackdriver plugin, supports monitored resource in
 
 If you are upgrading from a previous version please review the Upgrade Notes:
 
-[https://docs.fluentbit.io/manual/installation/upgrade-notes](https://docs.fluentbit.io/manual/installation/upgrade-notes)
+[https://docs.fluentbit.io/manual/1.6/installation/upgrade-notes](https://docs.fluentbit.io/manual/1.6/installation/upgrade-notes)
 
 Learn more about this plugin here:
 
-[https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver](https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver)
+[https://docs.fluentbit.io/manual/1.6/pipeline/outputs/stackdriver](https://docs.fluentbit.io/manual/1.6/pipeline/outputs/stackdriver)
 
 {{< contributor-list >}}
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 {{</ contributor-list >}}
 
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.6/v1.6.1.md
+++ b/content/announcements/v1.6/v1.6.1.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.6.1'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.6.1.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.6.1.'
 url: "/announcements/v1.6.1/"
 herobg: "/images/hero@2x.jpg"
 release_date: 2020-10-16
@@ -17,7 +17,7 @@ latestVer: true
 
 For people upgrading from previous versions you **must read** the Upgrading Notes section of our documentation:
 
-https://docs.fluentbit.io/manual/installation/upgrade_notes
+https://docs.fluentbit.io/manual/1.6/installation/upgrade_notes
 
 #### Changes
 
@@ -27,7 +27,7 @@ https://docs.fluentbit.io/manual/installation/upgrade_notes
 
 We have added a new native (built-in) [Loki](https://grafana.com/oss/loki/) output connector!. This new plugin is very flexible and supports customizable labels. For more details about it configuration please refer to the following document:
 
-[https://docs.fluentbit.io/manual/pipeline/outputs/loki](https://docs.fluentbit.io/manual/pipeline/outputs/loki)
+[https://docs.fluentbit.io/manual/1.6/pipeline/outputs/loki](https://docs.fluentbit.io/manual/1.6/pipeline/outputs/loki)
 
 ##### Other Fixes
 
@@ -47,7 +47,7 @@ We have added a new native (built-in) [Loki](https://grafana.com/oss/loki/) outp
 
 **Plugins**
 
-* [S3 (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/s3/)
+* [S3 (Output)](https://docs.fluentbit.io/manual/1.6/pipeline/outputs/s3/)
   * Run upload callback without async mode (#2677)
 
 
@@ -55,7 +55,7 @@ We have added a new native (built-in) [Loki](https://grafana.com/oss/loki/) outp
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 
 * [Eduardo Silva](https://github.com/edsiper)
@@ -66,7 +66,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.6/v1.6.10.md
+++ b/content/announcements/v1.6/v1.6.10.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.6.10'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.6.10.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.6.10.'
 url: "/announcements/v1.6.10/"
 herobg: "/images/hero@2x.jpg"
 release_date: 2021-01-08
@@ -17,13 +17,13 @@ latestVer: true
 
 For people upgrading from previous versions you **must read** the Upgrading Notes section of our documentation:
 
-[https://docs.fluentbit.io/manual/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
+[https://docs.fluentbit.io/manual/1.6/installation/upgrade_notes](https://docs.fluentbit.io/manual/1.6/installation/upgrade_notes)
 
 #### Give us Feedback!
 
-Dear user, we would love to learn more about your journey using Fluentd / Fluent Bit, if you want to give us some useful feedback please fill the **1 minute** community survey to help us understand your challenges and overall feedback:
+Dear user, we would love to learn more about your journey using Fluentd / Fluent Bit, if you want to give us some useful feedback please fill the **1-minute** community survey to help us understand your challenges and overall feedback:
 
-[https://www.cognitoforms.com/Fluentecosystem/FluentEcosystemSurvey](https://www.cognitoforms.com/Fluentecosystem/FluentEcosystemSurvey)
+[SURVEY CLOSED]
 
 If you are able to give us more than 1 minute of your time, let us know in the form so we can contact you back!
 
@@ -42,12 +42,12 @@ If you are able to give us more than 1 minute of your time, let us know in the f
 
 **Plugins**
 
-* [S3 (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/s3/)
+* [S3 (Output)](https://docs.fluentbit.io/manual/1.6/pipeline/outputs/s3/)
   * Fix multipart upload cache parsing (#2911)
   * S3 store: only store upload metadata once
   * auto-set putobject api when total file size is below the min size for multipart
   * Add content options
-* [Kafka (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/kafka/)
+* [Kafka (Output)](https://docs.fluentbit.io/manual/1.6/pipeline/outputs/kafka/)
   * Prevent segfault in error path (#2890)
 
 
@@ -55,7 +55,7 @@ If you are able to give us more than 1 minute of your time, let us know in the f
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 * [Wesley Pettit](https://github.com/PettitWesley)
 * [Giedrius Statkevičius](https://github.com/GiedriusS)
@@ -67,7 +67,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.6/v1.6.2.md
+++ b/content/announcements/v1.6/v1.6.2.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.6.2'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.6.2.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.6.2.'
 url: "/announcements/v1.6.2/"
 herobg: "/images/hero@2x.jpg"
 release_date: 2020-10-23
@@ -17,7 +17,7 @@ latestVer: true
 
 For people upgrading from previous versions you **must read** the Upgrading Notes section of our documentation:
 
-[https://docs.fluentbit.io/manual/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
+[https://docs.fluentbit.io/manual/1.6/installation/upgrade_notes](https://docs.fluentbit.io/manual/1.6/installation/upgrade_notes)
 
 #### Changes
 
@@ -33,11 +33,11 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 
 **Plugins**
 
-* [Winlog (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/winlog/)
+* [Winlog (Input)](https://docs.fluentbit.io/manual/1.6/pipeline/inputs/winlog/)
   * Add a new configuration option `string_inserts` (#2713)
-* [Loki (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/loki/)
+* [Loki (Output)](https://docs.fluentbit.io/manual/1.6/pipeline/outputs/loki/)
   * Perform label key names normalization (#2702 #2698)
-* [Elasticsearch (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/es/)
+* [Elasticsearch (Output)](https://docs.fluentbit.io/manual/1.6/pipeline/outputs/elasticsearch/)
   * Default AWS options to null in config map #2714 (#2720)
 
 
@@ -45,7 +45,7 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 * [William Orr](https://github.com/worr)
 * [Jeff Luo](https://github.com/JeffLuoo)
@@ -58,7 +58,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.6/v1.6.3.md
+++ b/content/announcements/v1.6/v1.6.3.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.6.3'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.6.3.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.6.3.'
 url: "/announcements/v1.6.3/"
 herobg: "/images/hero@2x.jpg"
 release_date: 2020-10-30
@@ -18,7 +18,7 @@ latestVer: true
 
 For people upgrading from previous versions you **must read** the Upgrading Notes section of our documentation:
 
-[https://docs.fluentbit.io/manual/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
+[https://docs.fluentbit.io/manual/1.6/installation/upgrade_notes](https://docs.fluentbit.io/manual/1.6/installation/upgrade_notes)
 
 #### Changes
 
@@ -34,7 +34,7 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 
 **Plugins**
 
-* [Loki (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/loki/)
+* [Loki (Output)](https://docs.fluentbit.io/manual/1.6/pipeline/outputs/loki/)
   * Validate labels_keys list is set or not at init (#2697)
 
 
@@ -42,7 +42,7 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 * [Fujimoto Seiji](https://github.com/fujimotos)
 * [Eduardo Silva](https://github.com/edsiper)
@@ -51,7 +51,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.6/v1.6.4.md
+++ b/content/announcements/v1.6/v1.6.4.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.6.4'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.6.4.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.6.4.'
 url: "/announcements/v1.6.4/"
 herobg: "/images/hero@2x.jpg"
 release_date: 2020-11-10
@@ -17,13 +17,13 @@ latestVer: true
 
 For people upgrading from previous versions you **must read** the Upgrading Notes section of our documentation:
 
-[https://docs.fluentbit.io/manual/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
+[https://docs.fluentbit.io/manual/1.6/installation/upgrade_notes](https://docs.fluentbit.io/manual/1.6/installation/upgrade_notes)
 
 #### Give us Feedback!
 
-Dear user, we would love to learn more about your journey using Fluentd / Fluent Bit, if you want to give us some useful feedback please fill the **1 minute** community survey to help us understand your challenges and overall feedback:
+Dear user, we would love to learn more about your journey using Fluentd / Fluent Bit, if you want to give us some useful feedback please fill the **1-minute** community survey to help us understand your challenges and overall feedback:
 
-[https://www.cognitoforms.com/Fluentecosystem/FluentEcosystemSurvey](https://www.cognitoforms.com/Fluentecosystem/FluentEcosystemSurvey)
+[SURVEY CLOSED]
 
 If you are able to give us more than 1 minute of your time, let us know in the form so we can contact you back!
 
@@ -34,13 +34,13 @@ If you are able to give us more than 1 minute of your time, let us know in the f
 
 **Core**
 
-* http_client: use HTTP_PROXY environment varialble for proxy globally
+* http_client: use HTTP_PROXY environment variable for proxy globally
 * io: fix flb_io_net_connect only opening sync connections (#2750)
 * lib: use context status to monitor thread
 * parser: fix to ensure string size is enough for comparison (oss-fuzz testcase 5200866812100608)
 * parser: ensure proper string null-termination (oss-fuzz 26327)
 * parser: fix insecure string pass (oss-fuzz 26325)
-* hash: fix null-derefence by ensure id is within size (oss-fuzz test case 5672848712269824)
+* hash: fix null-dereference by ensure id is within size (oss-fuzz test case 5672848712269824)
 * utils: fix case of empty string in time to sec conversion (oss-fuzz 26593)
 * utils: fix bad handling of utf-8 parsing (oss-fuzz 26304)
 * config_map: fix cases where kv->val is NULL (oss-fuzz issue 27023)
@@ -52,7 +52,7 @@ If you are able to give us more than 1 minute of your time, let us know in the f
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 * [Eduardo Silva](https://github.com/edsiper)
 * [David Korczynski](https://github.com/DavidKorczynski)
@@ -64,7 +64,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.6/v1.6.5.md
+++ b/content/announcements/v1.6/v1.6.5.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.6.5'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.6.5.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.6.5.'
 url: "/announcements/v1.6.5/"
 herobg: "/images/hero@2x.jpg"
 release_date: 2020-11-20
@@ -17,13 +17,13 @@ latestVer: true
 
 For people upgrading from previous versions you **must read** the Upgrading Notes section of our documentation:
 
-[https://docs.fluentbit.io/manual/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
+[https://docs.fluentbit.io/manual/1.6/installation/upgrade_notes](https://docs.fluentbit.io/manual/1.6/installation/upgrade_notes)
 
 #### Give us Feedback!
 
-Dear user, we would love to learn more about your journey using Fluentd / Fluent Bit, if you want to give us some useful feedback please fill the **1 minute** community survey to help us understand your challenges and overall feedback:
+Dear user, we would love to learn more about your journey using Fluentd / Fluent Bit, if you want to give us some useful feedback please fill the **1-minute** community survey to help us understand your challenges and overall feedback:
 
-[https://www.cognitoforms.com/Fluentecosystem/FluentEcosystemSurvey](https://www.cognitoforms.com/Fluentecosystem/FluentEcosystemSurvey)
+[SURVEY CLOSED]
 
 If you are able to give us more than 1 minute of your time, let us know in the form so we can contact you back!
 
@@ -44,17 +44,17 @@ If you are able to give us more than 1 minute of your time, let us know in the f
 
 **Plugins**
 
-* [Forward (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/forward/)
+* [Forward (Output)](https://docs.fluentbit.io/manual/1.6/pipeline/outputs/forward/)
   * Add `compress` option for gzip compression (#2773)
-* [Stackdriver (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver/)
+* [Stackdriver (Output)](https://docs.fluentbit.io/manual/1.6/pipeline/outputs/stackdriver/)
   * Add trace and custom log name support (#2683)
-* [Loki (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/loki/)
+* [Loki (Output)](https://docs.fluentbit.io/manual/1.6/pipeline/outputs/loki/)
   * New ‘line_format’ option, values: `json` (default), `key_value` (#2711)
   * Sanitize labels key names (#2793)
   * Add support for basic auth: `http_user` and `http_passwd`
-* [Syslog (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/syslog/)
+* [Syslog (Output)](https://docs.fluentbit.io/manual/1.6/pipeline/outputs/syslog/)
   * Fix `maxsize` value handling
-* [Cloudwatch_Logs (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch_logs/)
+* [Cloudwatch (Output)](https://docs.fluentbit.io/manual/1.6/pipeline/outputs/cloudwatch/)
   * Add `extra_user_agent` option
 
 
@@ -62,7 +62,7 @@ If you are able to give us more than 1 minute of your time, let us know in the f
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 * [Eduardo Silva](https://github.com/edsiper)
 * [Jim Minter](https://github.com/jim-minter)
@@ -76,7 +76,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.6/v1.6.6.md
+++ b/content/announcements/v1.6/v1.6.6.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.6.6'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.6.6.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.6.6.'
 url: "/announcements/v1.6.6/"
 herobg: "/images/hero@2x.jpg"
 release_date: 2020-11-24
@@ -17,13 +17,13 @@ latestVer: true
 
 For people upgrading from previous versions you **must read** the Upgrading Notes section of our documentation:
 
-[https://docs.fluentbit.io/manual/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
+[https://docs.fluentbit.io/manual/1.6/installation/upgrade_notes](https://docs.fluentbit.io/manual/1.6/installation/upgrade_notes)
 
 #### Give us Feedback!
 
-Dear user, we would love to learn more about your journey using Fluentd / Fluent Bit, if you want to give us some useful feedback please fill the **1 minute** community survey to help us understand your challenges and overall feedback:
+Dear user, we would love to learn more about your journey using Fluentd / Fluent Bit, if you want to give us some useful feedback please fill the **1-minute** community survey to help us understand your challenges and overall feedback:
 
-[https://www.cognitoforms.com/Fluentecosystem/FluentEcosystemSurvey](https://www.cognitoforms.com/Fluentecosystem/FluentEcosystemSurvey)
+[SURVEY CLOSED]
 
 If you are able to give us more than 1 minute of your time, let us know in the form so we can contact you back!
 
@@ -43,10 +43,10 @@ If you are able to give us more than 1 minute of your time, let us know in the f
 
 **Plugins**
 
-* [Tail (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/tail/)
+* [Tail (Input)](https://docs.fluentbit.io/manual/1.6/pipeline/inputs/tail/)
   * Dockermode: flush pending data on static files at exit (#2668)
   * Multiline: flush pending data on static files at exit (#2668)
-* [S3 (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/s3/)
+* [S3 (Output)](https://docs.fluentbit.io/manual/1.6/pipeline/outputs/s3/)
   * Add support for Canned ACL
 
 
@@ -55,7 +55,7 @@ If you are able to give us more than 1 minute of your time, let us know in the f
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 * [Eduardo Silva](https://github.com/edsiper)
 * [Zhonghui Hu](https://github.com/zhonghui12)
@@ -67,7 +67,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.6/v1.6.8.md
+++ b/content/announcements/v1.6/v1.6.8.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.6.8'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.6.8.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.6.8.'
 url: "/announcements/v1.6.8/"
 herobg: "/images/hero@2x.jpg"
 release_date: 2020-12-03
@@ -18,13 +18,13 @@ latestVer: true
 
 For people upgrading from previous versions you **must read** the Upgrading Notes section of our documentation:
 
-[https://docs.fluentbit.io/manual/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
+[https://docs.fluentbit.io/manual/1.6/installation/upgrade_notes](https://docs.fluentbit.io/manual/1.6/installation/upgrade_notes)
 
 #### Give us Feedback!
 
-Dear user, we would love to learn more about your journey using Fluentd / Fluent Bit, if you want to give us some useful feedback please fill the **1 minute** community survey to help us understand your challenges and overall feedback:
+Dear user, we would love to learn more about your journey using Fluentd / Fluent Bit, if you want to give us some useful feedback please fill the **1-minute** community survey to help us understand your challenges and overall feedback:
 
-[https://www.cognitoforms.com/Fluentecosystem/FluentEcosystemSurvey](https://www.cognitoforms.com/Fluentecosystem/FluentEcosystemSurvey)
+[SURVEY CLOSED]
 
 If you are able to give us more than 1 minute of your time, let us know in the form so we can contact you back!
 
@@ -49,11 +49,11 @@ If you are able to give us more than 1 minute of your time, let us know in the f
 
 **Plugins**
 
-* [HTTP (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/http/)
+* [HTTP (Output)](https://docs.fluentbit.io/manual/1.6/pipeline/outputs/http/)
   * Do not debug proxy if not enabled
-* [Gelf (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/gelf/)
+* [Gelf (Output)](https://docs.fluentbit.io/manual/1.6/pipeline/outputs/gelf/)
   * Accept possible level values (#2257)
-* [Biquery (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/biquery/)
+* [Biquery (Output)](https://docs.fluentbit.io/manual/1.6/pipeline/outputs/biquery/)
   * Should not discard the last character of URL (#2731)
 
 
@@ -61,7 +61,7 @@ If you are able to give us more than 1 minute of your time, let us know in the f
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 * [Fujimoto Seiji](https://github.com/fujimotos)
 * [Wesley Pettit](https://github.com/PettitWesley)
@@ -75,7 +75,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.6/v1.6.9.md
+++ b/content/announcements/v1.6/v1.6.9.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.6.9'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.6.9.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.6.9.'
 url: "/announcements/v1.6.9/"
 herobg: "/images/hero@2x.jpg"
 release_date: 2020-12-17
@@ -17,13 +17,13 @@ latestVer: true
 
 For people upgrading from previous versions you **must read** the Upgrading Notes section of our documentation:
 
-[https://docs.fluentbit.io/manual/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
+[https://docs.fluentbit.io/manual/1.6/installation/upgrade_notes](https://docs.fluentbit.io/manual/1.6/installation/upgrade_notes)
 
 #### Give us Feedback!
 
-Dear user, we would love to learn more about your journey using Fluentd / Fluent Bit, if you want to give us some useful feedback please fill the **1 minute** community survey to help us understand your challenges and overall feedback:
+Dear user, we would love to learn more about your journey using Fluentd / Fluent Bit, if you want to give us some useful feedback please fill the **1-minute** community survey to help us understand your challenges and overall feedback:
 
-[https://www.cognitoforms.com/Fluentecosystem/FluentEcosystemSurvey](https://www.cognitoforms.com/Fluentecosystem/FluentEcosystemSurvey)
+[SURVEY CLOSED]
 
 If you are able to give us more than 1 minute of your time, let us know in the form so we can contact you back!
 
@@ -39,10 +39,10 @@ If you are able to give us more than 1 minute of your time, let us know in the f
 
 **Plugins**
 
-* [S3 (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/s3/)
+* [S3 (Output)](https://docs.fluentbit.io/manual/1.6/pipeline/outputs/s3/)
   * Fix ‘\0’ assignment
   * Do not use ‘:’ in stream names on windows (#2855)
-* [Kafka (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/kafka/)
+* [Kafka (Output)](https://docs.fluentbit.io/manual/1.6/pipeline/outputs/kafka/)
   * Check only for first val.via.str.size chars (#2845)
 
 
@@ -50,7 +50,7 @@ If you are able to give us more than 1 minute of your time, let us know in the f
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 * [Fujimoto Seiji](https://github.com/fujimotos)
 * [Zero King](https://github.com/l2dy)
@@ -61,7 +61,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.7/v1.7.0.md
+++ b/content/announcements/v1.7/v1.7.0.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.7.0'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.7.0.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.7.0.'
 url: "/announcements/v1.7.0/"
 release_date: 2021-02-14
 publishdate: 2021-02-14
@@ -18,21 +18,19 @@ latestVer: true
 
 For people upgrading from previous versions you **must read** the Upgrading Notes section of our documentation:
 
-https://docs.fluentbit.io/manual/installation/upgrade_notes
+https://docs.fluentbit.io/manual/1.7/installation/upgrade_notes
 
 #### FluentCon is coming! May 4th! Save the Date
 
-The Fluent ecosystem keeps growing and now we are bringing the best of [Fluentd](https://www.fluentd.org) and [Fluent Bit](https://fluentbit.io)! More information click the banner below:
-
-[![image](https://fluentbit.io/assets/img/fluentcon-release.png)](https://events.linuxfoundation.org/fluentcon/)
+The Fluent ecosystem keeps growing, and now we are bringing the best of [Fluentd](https://www.fluentd.org) and [Fluent Bit](https://fluentbit.io)! 
 
 #### News
 
 [Fluent Bit](https://fluentbit.io) v1.7 is the next major release!, here you get the exciting news:
 
-##### Core: Multithread Support, 5x Performance!
+##### Core: Multithreading Support, 5x Performance!
 
-Most of users are very pleased with the high performance of Fluent Bit at a low cost of CPU and Memory. Our event-driven architecture and optimized handling of I/O through co-routines and buffering techniques is more than sufficient for most of cases. But running at high scale a single-thread program might face some limits since we were using a single CPU, and after working hard with our Cloud Providers partners like Google and Amazon, now we are pleased to introduce our new multi-thread architecture support: 5x times faster throughput!.
+Most users are very pleased with the high performance of Fluent Bit at a low cost of CPU and Memory. Our event-driven architecture and optimized handling of I/O through co-routines and buffering techniques is more than sufficient for most cases. But running at high scale a single-thread program might face some limits since we were using a single CPU, and after working hard with our Cloud Providers partners like Google and Amazon, now we are pleased to introduce our new multi-thread architecture support: 5x times faster throughput!.
 
 Running in multiple threads allows us to scale to multiple CPU and scale data processing and delivery at higher levels. This new mechanism can be configured at start time and can be enabled optionally per output connector (plugin). Now output connectors can run in multi thread mode using the new option `workers`. Example:
 
@@ -48,7 +46,7 @@ Running in multiple threads allows us to scale to multiple CPU and scale data pr
 
 The example above enable `4 workers` for the connector, so every data delivery procedure will run independently in a separate thread, further connections are balanced in a round-robin fashion.
 
-The multithread implementation is lock-free at runtime. One tip: if you are curious about the improvement, just try setting `workers 1` in your configuration, that option will force the engine to spawn a dedicated thread for data delivery, but note that this thread also can handle hundred of I/O requirements.
+The multithreading implementation is lock-free at runtime. One tip: if you are curious about the improvement, just try setting `workers 1` in your configuration, that option will force the engine to spawn a dedicated thread for data delivery, but note that this thread also can handle a hundred of I/O requirements.
 
 #### Core: New TLS/SSL Layer, OpenSSL!
 
@@ -56,23 +54,23 @@ Since day zero Fluent Bit supported TLS/SSL through the mbedTLS library. The lib
 
 ##### Tail Input (local files)
 
-The are two major enhancements on this version, now we provide a new configuration property called `offset_key` which optionally allows to append a key with the file offset to each record, and the known option `ignore_older` when enabled, now allows to skip unmodified files at start time and also stop monitoring files that have not modified in the interval of time set. This last property behavior change helps to reduce significantly the number of open file descriptors.
+There are two major enhancements on this version, now we provide a new configuration property called `offset_key` which optionally allows to append a key with the file offset to each record, and the known option `ignore_older` when enabled, now allows to skip unmodified files at start time and also stop monitoring files that have not modified in the interval of time set. This last property behavior change helps to reduce significantly the number of open file descriptors.
 
 #### HTTP input plugin (beta)
 
-We are including a new beta plugin that allows to receive data over HTTP protocol. This input plugin is fully functional and we expect extending it capabilities over the 1.7.x release cycle.
+We are including a new beta plugin that allows to receive data over HTTP protocol. This input plugin is fully functional, and we expect extending it capabilities over the 1.7.x release cycle.
 
 #### Filter GeoIP2
 
-Enrich your records with [geoip2](https://docs.fluentbit.io/manual/v/master/pipeline/filters/geoip2) data!. If you have records that contains IP addressed and need a country reference, this is the filter for you.
+Enrich your records with [geoip2](https://docs.fluentbit.io/manual/1.7/pipeline/filters/geoip2-filter) data!. If you have records that contains IP addressed and need a country reference, this is the filter for you.
 
 #### WebSocket Output
 
-We have introduced a new native [Websocket](https://docs.fluentbit.io/manual/v/master/pipeline/outputs/websocket) output plugin.
+We have introduced a new native [Websocket](https://docs.fluentbit.io/manual/1.7/pipeline/outputs/websocket) output plugin.
 
 #### Others
 
-There are tons of other imrpovements and fixes on this major release, here is a list of the most relevant ones:
+There are tons of other improvements and fixes on this major release, here is a list of the most relevant ones:
 
 
 **Core**
@@ -126,14 +124,14 @@ There are tons of other imrpovements and fixes on this major release, here is a 
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 {{</ contributor-list >}}
 
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.7/v1.7.1.md
+++ b/content/announcements/v1.7/v1.7.1.md
@@ -1,12 +1,11 @@
 ---
 title: 'v1.7.1'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.7.1.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.7.1.'
 url: "/announcements/v1.7.1/"
 herobg: "/images/hero@2x.jpg"
 release_date: 2021-02-19
 publishdate: 2021-02-19
 ver: v1.7.1
-herobg: "/images/hero@2x.jpg"
 latestVer: true
 ---
 
@@ -18,7 +17,7 @@ latestVer: true
 
 For people upgrading from previous versions you **must read** the Upgrading Notes section of our documentation:
 
-[https://docs.fluentbit.io/manual/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
+[https://docs.fluentbit.io/manual/1.7/installation/upgrade_notes](https://docs.fluentbit.io/manual/1.7/installation/upgrade_notes)
 
 #### Changes
 
@@ -37,9 +36,9 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 
 **Plugins**
 
-* [Storage_Backlog (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/storage_backlog/)
+* Storage_Backlog (Input)
   * Remove failed chunks from queue on load (#3089)
-* [Influxdb (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/influxdb/)
+* [Influxdb (Output)](https://docs.fluentbit.io/manual/1.7/pipeline/outputs/influxdb/)
   * Add experimental support for influxdb v2 (#3040)
 
 
@@ -48,7 +47,7 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 * [Eduardo Silva](https://github.com/edsiper)
 * [Filipe Pina](https://github.com/fopina)
@@ -57,7 +56,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.7/v1.7.2.md
+++ b/content/announcements/v1.7/v1.7.2.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.7.2'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.7.2.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.7.2.'
 url: "/announcements/v1.7.2/"
 release_date: 2021-03-03
 publishdate: 2021-03-03
@@ -17,7 +17,7 @@ latestVer: true
 
 For people upgrading from previous versions you **must read** the Upgrading Notes section of our documentation:
 
-[https://docs.fluentbit.io/manual/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
+[https://docs.fluentbit.io/manual/1.7/installation/upgrade_notes](https://docs.fluentbit.io/manual/1.7/installation/upgrade_notes)
 
 #### Changes
 
@@ -48,18 +48,18 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 
 **Plugins**
 
-* [Storage_Backlog (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/storage_backlog/)
+* Storage_Backlog (Input)
   * Extra checks and use content size for validation
-* [Dummy (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/dummy/)
+* [Dummy (Input)](https://docs.fluentbit.io/manual/1.7/pipeline/inputs/dummy/)
   * Support config map (#3135)
-* [Winlog (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/winlog/)
+* [Winlog (Input)](https://docs.fluentbit.io/manual/1.7/pipeline/inputs/winlog/)
   * Split an identifier into `eventid` and `qualifiers` (#3121)
-* [Kubernetes (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/kubernetes/)
+* [Kubernetes (Filter)](https://docs.fluentbit.io/manual/1.7/pipeline/filters/kubernetes/)
   * Fix coverity scan cid 161078 for code maintainability issue
   * Option for get meta information from kubelet /pods endpoint (experimental)
-* [Stackdriver (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver/)
+* [Stackdriver (Output)](https://docs.fluentbit.io/manual/1.7/pipeline/outputs/stackdriver/)
   * Added `export_to_project_id` option (#3113)
-* [Elasticsearch (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/es/)
+* [Elasticsearch (Output)](https://docs.fluentbit.io/manual/1.7/pipeline/outputs/elasticsearch/)
   * Add option `suppress_type_name` for v7.0.0 or later(#2869) (#3140)
 
 
@@ -67,7 +67,7 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 * [Takahiro Yamashita](https://github.com/nokute78)
 * [Richard Song](https://github.com/richardmcsong)
@@ -83,7 +83,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.7/v1.7.3.md
+++ b/content/announcements/v1.7/v1.7.3.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.7.3'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.7.3.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.7.3.'
 url: "/announcements/v1.7.3/"
 release_date: 2021-04-05
 publishdate: 2021-04-05
@@ -18,7 +18,7 @@ latestVer: true
 
 For people upgrading from previous versions you **must read** the Upgrading Notes section of our documentation:
 
-[https://docs.fluentbit.io/manual/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
+[https://docs.fluentbit.io/manual/1.7/installation/upgrade_notes](https://docs.fluentbit.io/manual/1.7/installation/upgrade_notes)
 
 #### Changes
 
@@ -42,14 +42,14 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 
 **Plugins**
 
-* [Tail (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/tail/)
+* [Tail (Input)](https://docs.fluentbit.io/manual/1.7/pipeline/inputs/tail/)
   * Add new configuration property `db.journal` (default: WAL) (#3239)
   * Pass missing argument processed_bytes (#3157)
-* [S3 (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/s3/)
+* [S3 (Output)](https://docs.fluentbit.io/manual/1.7/pipeline/outputs/s3/)
   * Support `uuid` in s3 key format
-* [Elasticsearch (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/es/)
+* [Elasticsearch (Output)](https://docs.fluentbit.io/manual/1.7/pipeline/outputs/elasticsearch/)
   * Support `id_key` to get id from record(#3303) (#3320)
-* [Splunk (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/splunk/)
+* [Splunk (Output)](https://docs.fluentbit.io/manual/1.7/pipeline/outputs/splunk/)
   * Remove allocation http_user/http_passwd (#3319)
   * Prioritize http basic auth over splunk token (#3231)
 
@@ -57,7 +57,7 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 * [Takahiro Yamashita](https://github.com/nokute78)
 * [Henrique Matulis](https://github.com/hsmatulisgoogle)
@@ -71,7 +71,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.7/v1.7.4.md
+++ b/content/announcements/v1.7/v1.7.4.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.7.4'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.7.4.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.7.4.'
 url: "/announcements/v1.7.4/"
 release_date: 2021-04-19
 publishdate: 2021-04-19
@@ -17,7 +17,7 @@ latestVer: true
 
 For people upgrading from previous versions you **must read** the Upgrading Notes section of our documentation:
 
-[https://docs.fluentbit.io/manual/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
+[https://docs.fluentbit.io/manual/1.7/installation/upgrade_notes](https://docs.fluentbit.io/manual/1.7/installation/upgrade_notes)
 
 #### Changes
 
@@ -35,12 +35,12 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 
 **Plugins**
 
-* [S3 (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/s3/)
+* [S3 (Output)](https://docs.fluentbit.io/manual/1.7/pipeline/outputs/s3/)
   * Optionally send content-md5 header to s3
   * Fix memory leak when gzip is enabled
-* [Stackdriver (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver/)
+* [Stackdriver (Output)](https://docs.fluentbit.io/manual/1.7/pipeline/outputs/stackdriver/)
   * New option `stackdriver_agent` to override HTTP user-agent (#3230)
-* [HTTP (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/http/)
+* [HTTP (Output)](https://docs.fluentbit.io/manual/1.7/pipeline/outputs/http/)
   * New `log_response_payload` option to enable or disable payload logging (#3348)
 
 
@@ -48,7 +48,7 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 * [Jorge Niedbalski](https://github.com/niedbalski)
 * [Lionel Cons](https://github.com/LionelCons)
@@ -62,7 +62,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.7/v1.7.5.md
+++ b/content/announcements/v1.7/v1.7.5.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.7.5'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.7.5.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.7.5.'
 url: "/announcements/v1.7.5/"
 release_date: 2021-05-13
 publishdate: 2021-05-13
@@ -17,7 +17,7 @@ latestVer: true
 
 For people upgrading from previous versions you **must read** the Upgrading Notes section of our documentation:
 
-[https://docs.fluentbit.io/manual/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
+[https://docs.fluentbit.io/manual/1.7/installation/upgrade_notes](https://docs.fluentbit.io/manual/1.7/installation/upgrade_notes)
 
 #### Changes
 
@@ -41,26 +41,26 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 
 **Plugins**
 
-* [Forward (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/forward/)
+* [Forward (Input)](https://docs.fluentbit.io/manual/1.7/pipeline/inputs/forward/)
   * Support config map
-* [Winlog (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/winlog/)
+* [Winlog (Input)](https://docs.fluentbit.io/manual/1.7/pipeline/inputs/winlog/)
   * Avoid sigsegv on invalid message placeholders (#3475)
-* [HTTP (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/http/)
+* [HTTP (Input)](https://docs.fluentbit.io/manual/1.7/pipeline/inputs/http/)
   * Fix socket fd leak
   * Changes for lambda extension logs support (#3298)
-* [Tail (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/tail/)
+* [Tail (Input)](https://docs.fluentbit.io/manual/1.7/pipeline/inputs/tail/)
   * Skip null characters from the head (#3117)
-* [Stackdriver (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver/)
+* [Stackdriver (Output)](https://docs.fluentbit.io/manual/1.7/pipeline/outputs/stackdriver/)
   * Fix invalid read of get_stream() function (#3480)
   * Enable custom regex to parse local_resource_id for stackdriver meta labels (#3342)
   * Enable upstream configuration
-* [Loki (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/loki/)
+* [Loki (Output)](https://docs.fluentbit.io/manual/1.7/pipeline/outputs/loki/)
   * Implement drop_single_key
   * Support new option tenant_id_key(#2935)
   * Change log level to suppress 200-205 status log (#3363)
-* [Splunk (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/splunk/)
+* [Splunk (Output)](https://docs.fluentbit.io/manual/1.7/pipeline/outputs/splunk/)
   * New `event_key` option and fixes for raw mode
-* [Cloudwatch_Logs (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch_logs/)
+* [Cloudwatch (Output)](https://docs.fluentbit.io/manual/1.7/pipeline/outputs/cloudwatch/)
   * Fix memory leak when using cpu or mem inputs (fluent#3145)
 
 
@@ -68,7 +68,7 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 
 * [Takahiro Yamashita](https://github.com/nokute78)
@@ -89,7 +89,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.7/v1.7.6.md
+++ b/content/announcements/v1.7/v1.7.6.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.7.6'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.7.6.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.7.6.'
 url: "/announcements/v1.7.6/"
 release_date: 2021-05-20
 publishdate: 2021-05-20
@@ -17,7 +17,7 @@ latestVer: true
 
 For people upgrading from previous versions you ***must read*** the Upgrading Notes section of our documentation:
 
-[https://docs.fluentbit.io/manual/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
+[https://docs.fluentbit.io/manual/1.7/installation/upgrade_notes](https://docs.fluentbit.io/manual/1.7/installation/upgrade_notes)
 
 #### Changes
 
@@ -37,12 +37,12 @@ For people upgrading from previous versions you ***must read*** the Upgrading No
 
 **Plugins**
 
-* [Tail (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/tail/)
+* [Tail (Input)](https://docs.fluentbit.io/manual/1.7/pipeline/inputs/tail/)
   * Fix handling of long lines (#3490)
   * Initialize mult_parsers list before parsing properties
-* [Http (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/http/)
+* [Http (Input)](https://docs.fluentbit.io/manual/1.7/pipeline/inputs/http/)
   * Add pipelining support
-* [Stackdriver (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver/)
+* [Stackdriver (Output)](https://docs.fluentbit.io/manual/1.7/pipeline/outputs/stackdriver/)
   * Drop log entries if http response code - 4xx
   * Adjust http header for new token
   * Implement cache for oauth2 token at thread level
@@ -52,7 +52,7 @@ For people upgrading from previous versions you ***must read*** the Upgrading No
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 * [jlunavtgrad](https://github.com/jlunavtgrad)
 * [Sophie Fang](https://github.com/sophieyfang)
@@ -68,7 +68,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.7/v1.7.7.md
+++ b/content/announcements/v1.7/v1.7.7.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.7.7'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.7.7.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.7.7.'
 url: "/announcements/v1.7.7/"
 herobg: "/images/hero@2x.jpg"
 release_date: 2021-05-26
@@ -18,7 +18,7 @@ latestVer: true
 
 For people upgrading from previous versions you **must read** the Upgrading Notes section of our documentation:
 
-[https://docs.fluentbit.io/manual/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
+[https://docs.fluentbit.io/manual/1.7/installation/upgrade_notes](https://docs.fluentbit.io/manual/1.7/installation/upgrade_notes)
 
 #### Changes
 
@@ -37,7 +37,7 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 * [Leonardo Alminana](https://github.com/leonardo-albertovich)
 * [Anurag Gupta](https://github.com/agup006)
@@ -48,7 +48,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.7/v1.7.8.md
+++ b/content/announcements/v1.7/v1.7.8.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.7.8'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.7.8.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.7.8.'
 url: "/announcements/v1.7.8/"
 herobg: "/images/hero@2x.jpg"
 release_date: 2021-06-02
@@ -17,7 +17,7 @@ latestVer: true
 
 For people upgrading from previous versions you **must read** the Upgrading Notes section of our documentation:
 
-[https://docs.fluentbit.io/manual/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
+[https://docs.fluentbit.io/manual/1.7/installation/upgrade_notes](https://docs.fluentbit.io/manual/1.7/installation/upgrade_notes)
 
 #### Changes
 
@@ -37,7 +37,7 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 * Yinjie Du
 * [Takahiro Yamashita](https://github.com/nokute78)
@@ -48,7 +48,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.7/v1.7.9.md
+++ b/content/announcements/v1.7/v1.7.9.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.7.9'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.7.9.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.7.9.'
 url: "/announcements/v1.7.9/"
 herobg: "/images/hero@2x.jpg"
 release_date: 2021-06-18
@@ -17,7 +17,7 @@ latestVer: true
 
 For people upgrading from previous versions you **must read** the Upgrading Notes section of our documentation:
 
-[https://docs.fluentbit.io/manual/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
+[https://docs.fluentbit.io/manual/1.7/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
 
 #### Changes
 
@@ -44,22 +44,22 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 
 **Plugins**
 
-* [Tail (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/tail/)
+* [Tail (Input)](https://docs.fluentbit.io/manual/1.7/pipeline/inputs/tail/)
   * Fix handling of ‘db.journal_mode’ option
-* [Kubernetes (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/kubernetes/)
+* [Kubernetes (Filter)](https://docs.fluentbit.io/manual/1.7/pipeline/filters/kubernetes/)
   * Add configurable ttl for cached metadata
-* [S3 (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/s3/)
+* [S3 (Output)](https://docs.fluentbit.io/manual/1.7/pipeline/outputs/s3/)
   * Fix documentation for total_file_size option
-* [Cloudwatch_Logs (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch_logs/)
+* [Cloudwatch (Output)](https://docs.fluentbit.io/manual/1.7/pipeline/outputs/cloudwatch/)
   * Fix log loss issue #3638
   * Fail request when x-amzn-requestid header is not set
-* [Loki (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/loki/)
+* [Loki (Output)](https://docs.fluentbit.io/manual/1.7/pipeline/outputs/loki/)
   * Release ra_kv at error case
-* [Bigquery (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/bigquery/)
+* [Bigquery (Output)](https://docs.fluentbit.io/manual/1.7/pipeline/outputs/bigquery/)
   * Always release unpacked results after formatting
   * On token renewal, cleanup oauth2 payload buffer
   * Fix oauth2 handling renewal and serialize access
-* [Stackdriver (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver/)
+* [Stackdriver (Output)](https://docs.fluentbit.io/manual/1.7/pipeline/outputs/stackdriver/)
   * Add new metrics ‘stackdriver_failed_requests’ and ‘stackdriver_successful_requests’
 
 
@@ -67,7 +67,7 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 * [Eduardo Silva](https://github.com/edsiper)
 * [Wesley Pettit](https://github.com/PettitWesley)
@@ -82,7 +82,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.8/v1.8.1.md
+++ b/content/announcements/v1.8/v1.8.1.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.8'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.8.1.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.8.1.'
 url: "/announcements/v1.8.1/"
 herobg: "/images/hero@2x.jpg"
 release_date: 2021-07-07
@@ -18,7 +18,7 @@ latestVer: true
 
 For people upgrading from previous versions you **must read** the Upgrading Notes section of our documentation:
 
-[https://docs.fluentbit.io/manual/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
+[https://docs.fluentbit.io/manual/1.8/installation/upgrade_notes](https://docs.fluentbit.io/manual/1.8/installation/upgrade_notes)
 
 #### News
 
@@ -36,7 +36,7 @@ Our new Metrics support has been a huge effort to implement several components. 
 * New output plugin called **Prometheus Exporter**: creates an HTTP end-point to expose metrics payloads in Prometheus format, so any metric can be scraped.
 * We developed new library [CMetrics](https://github.com/calyptia/cmetrics) to handle all the metrics needs: counters, gauges and shortly histograms (this last one is under development).
 
-In addition some output plugins now are aware about metrics payloads such as stdout, file and influxdb.
+In addition, some output plugins now are aware about metrics payloads such as stdout, file and influxdb.
 
 ##### Getting Started: Linux Node Metrics to Stdout:
 
@@ -52,7 +52,7 @@ docker run -v /proc:/host/proc -v /sys:/host/sys    \
 
 ##### Getting Started: Linux Node Metrics to Prometheus Exporter
 
-Similar example than above but now we switch to Prometheus Exporter output plugin which expose metrics on port 2021:
+Similar example than above, but now we switch to Prometheus Exporter output plugin which expose metrics on port 2021:
 
 ```
 docker run -p 2021:2021 -v /proc:/host/proc -v /sys:/host/sys    \
@@ -99,7 +99,7 @@ We have extended the capabilities of our Splunk connector, now it supports addit
 
 ##### New HTTP Health end point
 
-By using the new custom health enpoint `/api/v1/health`, you can get a more accurate information about how healthy is Fluent Bit, it calculate error and success rates to indicate a proper healthy status.
+By using the new custom health enpoint `/api/v1/health`, you can get a more accurate information about how healthy is Fluent Bit, it calculates error and success rates to indicate a proper healthy status.
 
 ##### Kubernetes Filter
 
@@ -109,13 +109,13 @@ Our Kubernetes filters uses an internal cache to store Pods metadata to avoid ge
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 {{</ contributor-list >}}
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.8/v1.8.10.md
+++ b/content/announcements/v1.8/v1.8.10.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.8.10'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.8.10.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.8.10.'
 url: "/announcements/v1.8.10/"
 herobg: "/images/hero@2x.jpg"
 release_date: 2021-11-19
@@ -17,7 +17,7 @@ latestVer: true
 
 For people upgrading from previous versions you **must read** the Upgrading Notes section of our documentation:
 
-[https://docs.fluentbit.io/manual/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
+[https://docs.fluentbit.io/manual/1.8/installation/upgrade_notes](https://docs.fluentbit.io/manual/1.8/installation/upgrade_notes)
 
 #### News
 
@@ -30,7 +30,7 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 * network: fixed error detection and handling (#4295)
 * output: added multithreaded worker support for proxy plugins
 * router: new interface to route and connect directly plugin instances
-* router: on exception of destination type mismath, use debug instead
+* router: on exception to destination type mismatch, use debug instead
 * task: process direct routes if they are set
 * parsers: add rabbitmq neo4j and dns custom parsers (#4324)
 
@@ -40,24 +40,24 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 
 **Plugins**
 
-* [Forward (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/forward/)
+* [Forward (Input)](https://docs.fluentbit.io/manual/1.8/pipeline/inputs/forward/)
   * Fix handling of TCP connections on SIGTERM (#2610)
-* [Modify (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/modify/)
+* [Modify (Filter)](https://docs.fluentbit.io/manual/1.8/pipeline/filters/modify/)
   * Check if key exists for `not` conditions (#4319)
-* [Aws (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/aws/)
+* [Aws (Filter)](https://docs.fluentbit.io/manual/1.8/pipeline/filters/aws-metadata/)
   * Expose metadata into main context environment
-* [Stackdriver (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver/)
+* [Stackdriver (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/stackdriver/)
   * Add new `http_request_key` configuration property (#4328)
-* [Cloudwatch_Logs (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch_logs/)
+* [Cloudwatch (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/cloudwatch/)
   * Auto retry invalid requests
-* [Calyptia Monitoring](https://docs.fluentbit.io/manual/administration/monitoring#calyptia-cloud)
+* [Calyptia Monitoring](https://docs.fluentbit.io/manual/1.8/administration/monitoring#calyptia-cloud)
   * Autodetect and send AWS metadata
 
 {{< contributor-list >}}
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 * [Leonardo Almiñana](https://github.com/leonardo-albertovich)
 * [Takahiro Yamashita](https://github.com/nokute78)
@@ -71,7 +71,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.8/v1.8.11.md
+++ b/content/announcements/v1.8/v1.8.11.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.8.11'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.8.10.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.8.10.'
 url: "/announcements/v1.8.11/"
 herobg: "/images/hero@2x.jpg"
 release_date: 2021-12-10
@@ -17,7 +17,7 @@ latestVer: true
 
 For people upgrading from previous versions you **must read** the Upgrading Notes section of our documentation:
 
-[https://docs.fluentbit.io/manual/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
+[https://docs.fluentbit.io/manual/1.8/installation/upgrade_notes](https://docs.fluentbit.io/manual/1.8/installation/upgrade_notes)
 
 #### News
 
@@ -44,11 +44,11 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 
 **Plugins**
 
-* [Forward (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/forward/)
+* [Forward (Input)](https://docs.fluentbit.io/manual/1.8/pipeline/inputs/forward/)
   * Removed unused variables (#4429)
-* [Rewrite_Tag (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/rewrite_tag/)
+* [Rewrite_Tag (Filter)](https://docs.fluentbit.io/manual/1.8/pipeline/filters/rewrite-tag/)
   * Add null check(#4246)
-* [Elasticsearch (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/es/)
+* [Elasticsearch (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/elasticsearch/)
   * Fix buffer size when converted_size is equal to 0\. (#4414)
 
 
@@ -56,7 +56,7 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 * [Eduardo Silva](https://github.com/edsiper)
 * [Lionel Cons](https://github.com/LionelCons)
@@ -70,7 +70,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.8/v1.8.12.md
+++ b/content/announcements/v1.8/v1.8.12.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.8.12'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.8.10.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.8.10.'
 url: "/announcements/v1.8.12/"
 release_date: 2022-01-24
 publishdate: 2022-01-24
@@ -17,7 +17,7 @@ latestVer: true
 
 For people upgrading from previous versions you **must read** the Upgrading Notes section of our documentation:
 
-[https://docs.fluentbit.io/manual/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
+[https://docs.fluentbit.io/manual/1.8/installation/upgrade_notes](https://docs.fluentbit.io/manual/1.8/installation/upgrade_notes)
 
 #### News
 
@@ -52,40 +52,40 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 
 **Plugins**
 
-* [Forward (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/forward/)
+* [Forward (Input)](https://docs.fluentbit.io/manual/1.8/pipeline/inputs/forward/)
   * Clear out_tag before using it (#4670)
   * Add new option `tag_prefix` (#4455) (#4466)
-* [Tail (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/tail/)
+* [Tail (Input)](https://docs.fluentbit.io/manual/1.8/pipeline/inputs/tail/)
   * Enhance handling of high number of static files (#3947)
   * Fix multiline api buffer ingestion (#4554)
-* [Exec (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/exec/)
+* [Exec (Input)](https://docs.fluentbit.io/manual/1.8/pipeline/inputs/exec/)
   * Don’t eat last character of plugin output (#4655)
-* [Rewrite_Tag (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/rewrite_tag/)
+* [Rewrite_Tag (Filter)](https://docs.fluentbit.io/manual/1.8/pipeline/filters/rewrite-tag/)
   * Set ‘keep’ before emitting the record (#4518)
-* [Multiline (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/multiline/)
+* [Multiline (Filter)](https://docs.fluentbit.io/manual/1.8/pipeline/filters/multiline-stacktrace/)
   * Implement buffered mode using in_emitter
-* [S3 (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/s3/)
+* [S3 (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/s3/)
   * Add support for external_id
-* [Kinesis_Firehose (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/kinesis_firehose/)
+* [Kinesis_Firehose (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/firehose/)
   * Add support for external_id
-* [Cloudwatch_Logs (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch_logs/)
+* [Cloudwatch (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/cloudwatch/)
   * Add support for external_id
   * Fix invalid memory access bug #4425
-* [Splunk (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/splunk/)
+* [Splunk (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/splunk/)
   * New `http_debug_bad_request` option
   * Auto-set http response buffer size if `http_buffer_size` is not set or zero
-* [Forward (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/forward/)
+* [Forward (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/forward/)
   * Add missing ra check (#4511)
-* [Stackdriver (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver/)
+* [Stackdriver (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/stackdriver/)
   * Protect against undefined metadata (#4664)
-* [Kinesis_Streams (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/kinesis_streams/)
+* [Kinesis_Streams (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/kinesis/)
   * Add support for external_id
 
 {{< contributor-list >}}
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 * [Ramya Krishnamoorthy](https://github.com/krispraws)
 * [Leonardo Alminana](https://github.com/leonardo-albertovich)
@@ -100,7 +100,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.8/v1.8.13.md
+++ b/content/announcements/v1.8/v1.8.13.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.8.13'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
 url: "/announcements/v1.8.13/"
 release_date: 2022-03-01
 publishdate: 2022-03-01
@@ -17,7 +17,7 @@ latestVer: true
 
 For people upgrading from previous versions you **must read** the Upgrading Notes section of our documentation:
 
-[https://docs.fluentbit.io/manual/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
+[https://docs.fluentbit.io/manual/1.8/installation/upgrade_notes](https://docs.fluentbit.io/manual/1.8/installation/upgrade_notes)
 
 #### News
 
@@ -51,49 +51,49 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 
 **Plugins**
 
- - [Storage_Backlog (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/storage_backlog/)
+ - Storage_Backlog (Input)
     - Do not abort if chunk cannot be processed
- - [Tail (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/tail/)
+ - [Tail (Input)](https://docs.fluentbit.io/manual/1.8/pipeline/inputs/tail/)
     - Do not use st_dev on windows
     - Performance improvement on management of file list
- - [Systemd (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/systemd/)
+ - [Systemd (Input)](https://docs.fluentbit.io/manual/1.8/pipeline/inputs/systemd/)
     - Skip broken entry
- - [Rewrite_Tag (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/rewrite_tag/)
+ - [Rewrite_Tag (Filter)](https://docs.fluentbit.io/manual/1.8/pipeline/filters/rewrite-tag/)
     - Fix match aborting issue (#4276)
- - [Expect (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/expect/)
+ - [Expect (Filter)](https://docs.fluentbit.io/manual/1.8/pipeline/filters/expect/)
     - Exit with 255 on failure (#4846)
- - [HTTP (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/http/)
+ - [HTTP (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/http/)
     - Set 2 workers by default
-  - [Prometheus_Remote_Write (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/prometheus_remote_write/)
+  - [Prometheus_Remote_Write (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/prometheus-remote-write/)
     - Set 2 workers by default
- - [Stdout (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/stdout/)
+ - [Stdout (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/standard-output/)
     - Set 1 worker by default
- - [S3 (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/s3/)
+ - [S3 (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/s3/)
     - Add default 1 workers
     - Migrate to performant base64 implementation
- - [Kinesis_Firehose (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/kinesis_firehose/)
+ - [Kinesis_Firehose (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/firehose/)
     - Add default 1 worker
     - Migrate to performant base64 implementation
- - [Tcp (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/tcp/)
+ - [Tcp (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/tcp/)
     - Set 2 workers by default
- - [Prometheus_Exporter (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/prometheus_exporter/)
+ - [Prometheus_Exporter (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/prometheus-exporter/)
     - Add new option 'add_timestamp', disabled by default
- - [File (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/file/)
+ - [File (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/file/)
     - Set 1 worker by default
- - [Splunk (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/splunk/)
+ - [Splunk (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/splunk/)
     - Set 2 workers by default
- - [Forward (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/forward/)
+ - [Forward (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/forward/)
     - Set 2 workers by default
- - [Stackdriver (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver/)
+ - [Stackdriver (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/stackdriver/)
       - Set 2 workers by default
       - Check for proper http request key
       - Add new metric 'fluentbit_stackdriver_requests_total' (#2698)
       - Correct env variable for sas (#4763)
- - [Null (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/null/)
+ - [Null (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/null/)
     - Set 1 worker by default
- - [Elasticsearch (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/es/)
+ - [Elasticsearch (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/elasticsearch/)
     - Set 2 workers by default
- - [Kinesis_Streams (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/kinesis_streams/)
+ - [Kinesis_Streams (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/kinesis/)
     - Add default 1 worker
     - Migrate to performant base64 implementation
 
@@ -101,7 +101,7 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 * [Ramya Krishnamoorthy](https://github.com/krispraws)
 * [Leonardo Alminana](https://github.com/leonardo-albertovich)
@@ -116,7 +116,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.8/v1.8.14.md
+++ b/content/announcements/v1.8/v1.8.14.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.8.14'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
 url: "/announcements/v1.8.14/"
 release_date: 2022-03-18
 publishdate: 2022-03-18
@@ -21,14 +21,14 @@ The __v1.8__ series is on maintenance mode only, where it receives critical fixe
 #### Fixes
 
  - Plugins
-   - [Systemd (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/systemd/)
+   - [Systemd (Input)](https://docs.fluentbit.io/manual/1.8/pipeline/inputs/systemd/)
       - Backport new `lowercase` option (#4992)
-   - [Tail (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/tail/)
+   - [Tail (Input)](https://docs.fluentbit.io/manual/1.8/pipeline/inputs/tail/)
       - On file rotation, remove entry from hash tables
-   - [Cloudwatch_Logs (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch_logs/)
+   - [Cloudwatch (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/cloudwatch/)
       - Fix build issue from #4826
       - Only create log group if it does not already exist to prevent throttling
-   - [Loki (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/loki/)
+   - [Loki (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/loki/)
       - Reduce accessor noise
 
 
@@ -36,7 +36,7 @@ The __v1.8__ series is on maintenance mode only, where it receives critical fixe
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 - [Eduardo Silva](https://github.com/edsiper)
 - [zhenyami](https://github.com/zhenyami)
@@ -48,7 +48,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.8/v1.8.15.md
+++ b/content/announcements/v1.8/v1.8.15.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.8.15'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
 url: "/announcements/v1.8.15/"
 release_date: 2022-03-23
 publishdate: 2022-03-23
@@ -29,7 +29,7 @@ The __v1.8__ series is on maintenance mode only, where it receives critical fixe
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 - [Leonardo Alminana](https://github.com/leonardo-albertovich)
 
@@ -37,7 +37,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.8/v1.8.2.md
+++ b/content/announcements/v1.8/v1.8.2.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.8.2'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.8.2.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.8.2.'
 url: "/announcements/v1.8.2/"
 herobg: "/images/hero@2x.jpg"
 release_date: 2021-07-20
@@ -17,15 +17,15 @@ latestVer: true
 
 For people upgrading from previous versions you **must read** the Upgrading Notes section of our documentation:
 
-[https://docs.fluentbit.io/manual/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
+[https://docs.fluentbit.io/manual/1.8/installation/upgrade_notes](https://docs.fluentbit.io/manual/1.8/installation/upgrade_notes)
 
 #### Quick Summary of “New things”
 
 ##### New Multiline, Filter and Documentation
 
-* [Multiline Filter](https://docs.fluentbit.io/manual/pipeline/filters/multiline-stacktrace)
-* [Multiline Parsing Config](https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/multiline-parsing)
-* [Tail + New Multiline Support](https://docs.fluentbit.io/manual/pipeline/inputs/tail#multiline-support)
+* [Multiline Filter](https://docs.fluentbit.io/manual/1.8/pipeline/filters/multiline-stacktrace)
+* [Multiline Parsing Config](https://docs.fluentbit.io/manual/1.8/administration/configuring-fluent-bit/multiline-parsing)
+* [Tail + New Multiline Support](https://docs.fluentbit.io/manual/1.8/pipeline/inputs/tail#multiline-support)
 
 #### News
 
@@ -53,35 +53,35 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 
 **Plugins**
 
-* [Tail (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/tail/)
+* [Tail (Input)](https://docs.fluentbit.io/manual/1.8/pipeline/inputs/tail/)
   * Add new option `skip_empty_lines` (default: false)
-* [Node_Exporter_Metrics (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/node_exporter_metrics/)
+* [Node Exporter Metrics (Input)](https://docs.fluentbit.io/manual/1.8/pipeline/inputs/node-exporter-metrics/)
   * Do not enqueue data before the collector start
   * Fix compiler warnings
   * Add `filefd` Linux collector
   * Add `vmstat` and `netdev` Linux collectors
-* [Multiline (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/multiline/)
+* [Multiline (Filter)](https://docs.fluentbit.io/manual/1.8/pipeline/filters/multiline/)
   * New `multiline` filter
-* [S3 (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/s3/)
+* [S3 (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/s3/)
   * Fix compiler warnings
   * Fix use-after-free in destructor
-* [Prometheus_Remote_Write (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/prometheus_remote_write/)
+* [Prometheus Remote Write (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/prometheus-remote-write/)
   * New Prometheus Remote Write output plugin
-* [Influxdb (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/influxdb/)
+* [Influxdb (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/influxdb/)
   * Enable http debug callbacks
   * Rename option `header` as `http_header`
   * Migrate to configmap and append new options
   * Add support for native metrics handling
-* [Kafka (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/kafka/)
+* [Kafka (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/kafka/)
   * Upgrade librdkafka v1.6.0 to v1.7.0
-* [Prometheus_Exporter (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/prometheus_exporter/)
+* [Prometheus Exporter (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/prometheus-exporter/)
   * Support multiple metrics
   * Remove unused variable
-* [Splunk (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/splunk/)
+* [Splunk (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/splunk/)
   * Set channel len on init
-* [Loki (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/loki/)
+* [Loki (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/loki/)
   * Do not retry when Loki returns 400.
-* [Elasticsearch (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/es/)
+* [Elasticsearch (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/elasticsearch/)
   * Estimate bulk size to less reallocation(#3775)
 
 
@@ -89,7 +89,7 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 * [Eduardo Silva](https://github.com/edsiper)
 * [Jesse Rittner](https://github.com/rittneje)
@@ -102,7 +102,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.8/v1.8.3.md
+++ b/content/announcements/v1.8/v1.8.3.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.8.3'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.8.3.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.8.3.'
 url: "/announcements/v1.8.3/"
 herobg: "/images/hero@2x.jpg"
 release_date: 2021-08-02
@@ -18,7 +18,7 @@ latestVer: true
 
 For people upgrading from previous versions you **must read** the Upgrading Notes section of our documentation:
 
-[https://docs.fluentbit.io/manual/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
+[https://docs.fluentbit.io/manual/1.8/installation/upgrade_notes](https://docs.fluentbit.io/manual/1.8/installation/upgrade_notes)
 
 #### News
 
@@ -41,11 +41,11 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 
 **Plugins**
 
-* [Tail (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/tail/)
+* [Tail (Input)](https://docs.fluentbit.io/manual/1.8/pipeline/inputs/tail/)
   * Add custom keys to multiline payload
-* [Multiline (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/multiline/)
+* [Multiline (Filter)](https://docs.fluentbit.io/manual/1.8/pipeline/filters/multiline-stacktrace/)
   * Flush before return and added new option ‘debug_flush’
-* [S3 (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/s3/)
+* [S3 (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/s3/)
   * Re-added static file path configuration option
   * Added file permission fix and flb_errno to read / write file
   * Fixed potential segfault on file discard
@@ -53,16 +53,16 @@ For people upgrading from previous versions you **must read** the Upgrading Note
   * Added sequential index feature
   * Log_key configuration option implemented
   * Added static file path configuration option
-* [Loki (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/loki/)
+* [Loki (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/loki/)
   * Delay mp_sbuf->data derefence (#3796)
-* [Prometheus_Remote_Write (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/prometheus_remote_write/)
+* [Prometheus Remote Write (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/prometheus-remote-write/)
   * Concatenate cmetrics buffers
 
 
 {{< contributor-list >}}
 #### Contributors  
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 
 * [Stephen Lee](https://github.com/StephenLeeY)
@@ -76,7 +76,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.8/v1.8.4.md
+++ b/content/announcements/v1.8/v1.8.4.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.8.4'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.8.4.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.8.4.'
 url: "/announcements/v1.8.4/"
 herobg: "/images/hero@2x.jpg"
 release_date: 2021-08-20
@@ -17,7 +17,7 @@ latestVer: true
 
 For people upgrading from previous versions you **must read** the Upgrading Notes section of our documentation:
 
-[https://docs.fluentbit.io/manual/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
+[https://docs.fluentbit.io/manual/1.8/installation/upgrade_notes](https://docs.fluentbit.io/manual/1.8/installation/upgrade_notes)
 
 #### News
 
@@ -53,31 +53,31 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 
 * Calyptia (Custom)
   * New Calyptia ‘custom’ plugin to monitor agents with [Calyptia Cloud](https://cloud.calyptia.com)
-* [Fluentbit_Metrics (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/fluentbit_metrics/)
+* [Fluentbit Metrics (Input)](https://docs.fluentbit.io/manual/1.8/pipeline/inputs/fluentbit-metrics/)
   * New plugin to emit Fluent Bit internal metrics
   * Extend collectors to ‘start’ and ‘runtime’
-* [Tail (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/tail/)
+* [Tail (Input)](https://docs.fluentbit.io/manual/1.8/pipeline/inputs/tail/)
   * Initialize crlf (#3943)
   * Add cmetrics support
-* [Checklist (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/checklist/)
+* [Checklist (Filter)](https://docs.fluentbit.io/manual/1.8/pipeline/filters/checklist/)
   * New filter to flag records based on matching strings (#3869)
-* [Rewrite_Tag (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/rewrite_tag/)
+* [Rewrite Tag (Filter)](https://docs.fluentbit.io/manual/1.8/pipeline/filters/rewrite-tag/)
   * Implement cmetrics support
-* [Datadog (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/datadog/)
+* [Datadog (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/datadog/)
   * Do not print api_key in debug logs
-* [S3 (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/s3/)
+* [S3 (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/s3/)
   * Added file permission executable fix
-* [Prometheus_Exporter (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/prometheus_exporter/)
+* [Prometheus Exporter (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/prometheus-exporter/)
   * Do not process empty metrics context
-* [Splunk (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/splunk/)
+* [Splunk (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/splunk/)
   * If ‘event_key’ is missing, pack as a normal map
-* [Stackdriver (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver/)
+* [Stackdriver (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/stackdriver/)
   * Add cmetrics support
-* [Loki (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/loki/)
+* [Loki (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/loki/)
   * Remove kv only if ‘remove_keys’ enabled (#3867)
-* [Elasticsearch (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/es/)
+* [Elasticsearch (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/elasticsearch/)
   * Check if converted_size is 0 to prevent sigfpe (#3905)
-* [Calyptia (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/calyptia/)
+* [Calyptia (Output)](https://docs.fluentbit.io/manual/1.8/administration/monitoring#calyptia-cloud)
   * New ‘calyptia cloud’ private plugin
 
 
@@ -86,7 +86,7 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 * [Eduardo Silva](https://github.com/edsiper)
 * [Fujimoto Seiji](https://github.com/fujimotos)
@@ -94,14 +94,14 @@ On every release, there are many people involved doing contributions on differen
 * [Takahiro Yamashita](https://github.com/nokute78)
 * [Tori Hara](https://github.com/toricls)
 * [Wesley Pettit](https://github.com/PettitWesley)
-* [Simon A. Eugster](Granjow)
+* [Simon A. Eugster](https://github.com/Granjow)
 * [Stephen Lee](https://github.com/StephenLeeY)
 
 {{< /contributor-list >}}
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.8/v1.8.5.md
+++ b/content/announcements/v1.8/v1.8.5.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.8.5'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.8.5.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.8.5.'
 url: "/announcements/v1.8.5/"
 herobg: "/images/hero@2x.jpg"
 release_date: 2021-08-27
@@ -17,7 +17,7 @@ latestVer: true
 
 For people upgrading from previous versions you **must read** the Upgrading Notes section of our documentation:
 
-[https://docs.fluentbit.io/manual/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
+[https://docs.fluentbit.io/manual/1.8/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
 
 #### News
 
@@ -38,7 +38,7 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 
 **Plugins**
     
-* [Forward (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/forward/)
+* [Forward (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/forward/)
   * Add support to forward metrics
 
 
@@ -47,7 +47,7 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 #### Contributors
 
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 
 * [Leonardo Alminana](https://github.com/leonardo-albertovich)
@@ -57,7 +57,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.8/v1.8.6.md
+++ b/content/announcements/v1.8/v1.8.6.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.8.6'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.8.6.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.8.6.'
 url: "/announcements/v1.8.6/"
 herobg: "/images/hero@2x.jpg"
 release_date: 2021-09-01
@@ -17,7 +17,7 @@ latestVer: true
 
 For people upgrading from previous versions you **must read** the Upgrading Notes section of our documentation:
 
-[https://docs.fluentbit.io/manual/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
+[https://docs.fluentbit.io/manual/1.8/installation/upgrade_notes](https://docs.fluentbit.io/manual/1.8/installation/upgrade_notes)
 
 #### News
 
@@ -33,9 +33,9 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 
 **Plugins**
 
-* [Tail (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/tail/)
+* [Tail (Input)](https://docs.fluentbit.io/manual/1.8/pipeline/inputs/tail/)
   * Fix cmetric label name
-* [S3 (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/s3/)
+* [S3 (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/s3/)
   * Don’t complete uploads that were never created
 
 
@@ -43,7 +43,7 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 * [Eduardo Silva](https://github.com/edsiper)
 * [Wesley Pettit](https://github.com/PettitWesley)
@@ -53,7 +53,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.8/v1.8.7.md
+++ b/content/announcements/v1.8/v1.8.7.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.8.7'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.8.7.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.8.7.'
 url: "/announcements/v1.8.7/"
 herobg: "/images/hero@2x.jpg"
 release_date: 2021-09-17
@@ -18,7 +18,7 @@ latestVer: true
 
 For people upgrading from previous versions you **must read** the Upgrading Notes section of our documentation:
 
-[https://docs.fluentbit.io/manual/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
+[https://docs.fluentbit.io/manual/1.8/installation/upgrade_notes](https://docs.fluentbit.io/manual/1.8/installation/upgrade_notes)
 
 #### News
 
@@ -41,27 +41,27 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 
 **Plugins**
 
-* [Lua (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/lua/)
+* [Lua (Filter)](https://docs.fluentbit.io/manual/1.8/pipeline/filters/lua/)
   * Calculate table size using table.maxn (#3433)
-* [Nest (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/nest/)
+* [Nest (Filter)](https://docs.fluentbit.io/manual/1.8/pipeline/filters/nest/)
   * Change log level (#4005)
-* [Record_Modifier (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/record_modifier/)
+* [Record Modifier (Filter)](https://docs.fluentbit.io/manual/1.8/pipeline/filters/record-modifier/)
   * Set the limit of bool_map
   * Dynamic allocate bool_map (#3968)
-* [Kubernetes (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/kubernetes/)
+* [Kubernetes (Filter)](https://docs.fluentbit.io/manual/1.8/pipeline/filters/kubernetes/)
   * New option `use_tag_for_meta` to use tag for metadata (#4062)
-* [S3 (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/s3/)
+* [S3 (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/s3/)
   * Support auto_retry_requests for failed connections
-* [Prometheus_Exporter (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/prometheus_exporter/)
+* [Prometheus Exporter (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/prometheus-exporter/)
   * Use instance host/port api (#4070) (#4081)
-* [Cloudwatch_Logs (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch_logs/)
+* [Cloudwatch Logs (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/cloudwatch/)
   * Support `auto_retry_requests` for failed connections
-* [Elasticsearch (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/es/)
+* [Elasticsearch (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/elasticsearch/)
   * AWS is rebranding to Amazon OpenSearch service (text changes only)
-* [Kinesis_Streams (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/kinesis_streams/)
+* [Kinesis Streams (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/kinesis/)
   * Change log level from `info` to `debug` for log send statement
   * Support `auto_retry_requests` for failed connections
-* [Kinesis_Firehose (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/kinesis_firehose/)
+* [Kinesis Firehose (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/firehose/)
   * Change log level from `info` to `debug` for log send statement
   * Support `auto_retry_requests` for failed connections
 
@@ -71,7 +71,7 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 * [Leonardo Alminana](https://github.com/leonardo-albertovich)
 * [Takahiro Yamashita](https://github.com/nokute78)
@@ -85,7 +85,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.8/v1.8.8.md
+++ b/content/announcements/v1.8/v1.8.8.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.8.8'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.8.8.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.8.8.'
 url: "/announcements/v1.8.8/"
 herobg: "/images/hero@2x.jpg"
 release_date: 2021-10-10
@@ -17,7 +17,7 @@ latestVer: true
 
 For people upgrading from previous versions you **must read** the Upgrading Notes section of our documentation:
 
-[https://docs.fluentbit.io/manual/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
+[https://docs.fluentbit.io/manual/1.8/installation/upgrade_notes](https://docs.fluentbit.io/manual/1.8/installation/upgrade_notes)
 
 #### News
 
@@ -51,15 +51,15 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 * Storage_Backlog
   * Properly handle when storage is not set
   * Added segregated queues and selective chunk dropping
-* [Winlog (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/winlog/)
+* [Winlog (Input)](https://docs.fluentbit.io/manual/1.8/pipeline/inputs/winlog/)
   * Support `use_ansi` config property (#4129)
-* [Http (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/http/)
+* [Http (Input)](https://docs.fluentbit.io/manual/1.8/pipeline/inputs/http/)
   * Add lack of initialization and error handling (#4130)
-* [S3 (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/s3/)
+* [S3 (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/s3/)
   * Add back flb_sds_destroy() lost in 8cd50f8 (#4038)
-* [Cloudwatch_Logs (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch_logs/)
+* [Cloudwatch Logs (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/cloudwatch/)
   * Resolve unpaired trailing backslash sanitization failure
-* [Bigquery (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/bigquery/)
+* [Bigquery (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/bigquery/)
   * Add `skipinvalidrows` and `ignoreunknownvalues` params (#4158)
 
 
@@ -68,7 +68,7 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 * [zhenyami](https://github.com/zhenyami)
 * [Leonardo Alminana](https://github.com/leonardo-albertovich)
@@ -82,7 +82,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.8/v1.8.9.md
+++ b/content/announcements/v1.8/v1.8.9.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.8.9'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.8.9.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD and OSX. We are proud to announce the availability of Fluent Bit v1.8.9.'
 url: "/announcements/v1.8.9/"
 herobg: "/images/hero@2x.jpg"
 release_date: 2021-10-28
@@ -17,7 +17,7 @@ latestVer: true
 
 For people upgrading from previous versions you **must read** the Upgrading Notes section of our documentation:
 
-[https://docs.fluentbit.io/manual/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
+[https://docs.fluentbit.io/manual/1.8/installation/upgrade_notes](https://docs.fluentbit.io/manual/1.8/installation/upgrade_notes)
 
 #### News
 
@@ -40,28 +40,28 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 
 **Plugins**
 
-* [Tail (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/tail/)
+* [Tail (Input)](https://docs.fluentbit.io/manual/1.8/pipeline/inputs/tail/)
   * Avoid double free for multiline msgpack buffer
   * On Multiline handling, use file inode as stream_id (#4190)
-* [Node_Exporter_Metrics (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/node_exporter_metrics/)
+* [Node Exporter Metrics (Input)](https://docs.fluentbit.io/manual/1.8/pipeline/inputs/node-exporter-metrics/)
   * Ensure zero with epsilon on double type factor
-* [Emitter (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/emitter/)
+* Emitter (Input)
   * Write msgpack buffer directly, remove local queue (#4049)
-* [Rewrite_Tag (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/rewrite_tag/)
+* [Rewrite Tag (Filter)](https://docs.fluentbit.io/manual/1.8/pipeline/filters/rewrite-tag/)
   * Prevent to emit original record when in_emit pauses
   * Abort when infinite loop setting
-* [Modify (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/modify/)
+* [Modify (Filter)](https://docs.fluentbit.io/manual/1.8/pipeline/filters/modify/)
   * Change log level to suppress (#4210)
-* [Kubernetes (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/kubernetes/)
+* [Kubernetes (Filter)](https://docs.fluentbit.io/manual/1.8/pipeline/filters/kubernetes/)
   * Expose metadata for internal usage
-* [Stackdriver (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver/)
+* [Stackdriver (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/stackdriver/)
   * Print warning message on error response
-* [Custom_Calyptia (Output)](https://docs.fluentbit.io/manual/administration/monitoring#calyptia-cloud)
+* [Custom_Calyptia (Output)](https://docs.fluentbit.io/manual/1.8/administration/monitoring#calyptia-cloud)
   * Enable machine_id config property.
   * Enable add_label property. (#4176)
-* [Prometheus_Remote_Write (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/prometheus_remote_write/)
+* [Prometheus Remote Write (Output)](https://docs.fluentbit.io/manual/1.8/pipeline/outputs/prometheus-remote-write/)
   * Add `add_label` support, so now you can add your custom labels.
-* [Calyptia (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/custom_calyptia/)
+* [Calyptia (Output)](https://docs.fluentbit.io/manual/1.8/administration/monitoring#calyptia-cloud)
   * Expose Kubernetes basic metadata
 
 
@@ -69,7 +69,7 @@ For people upgrading from previous versions you **must read** the Upgrading Note
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 
 * [Jorge Niedbalski](https://github.com/niedbalski)
@@ -84,7 +84,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.9/v1.9.0.md
+++ b/content/announcements/v1.9/v1.9.0.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.9.0'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
 url: "/announcements/v1.9.0/"
 release_date: 2022-03-11
 publishdate: 2022-03-11
@@ -17,7 +17,7 @@ latestVer: true
 
 For people upgrading from previous versions you **must read** the Upgrading Notes section of our documentation:
 
-[https://docs.fluentbit.io/manual/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
+[https://docs.fluentbit.io/manual/1.9/installation/upgrade_notes](https://docs.fluentbit.io/manual/1.9/installation/upgrade_notes)
 
 #### Introduction
 
@@ -30,7 +30,7 @@ We have been hard working on extending __metrics__ support in Fluent Bit, meanin
 and delivery. We fully support __Prometheus & OpenMetrics__ and we are also shipping experimental __OpenTelemetry__ metrics support (spoiler: traces will come shortly!). A new Nginx Metrics scraper plugin
 is part of this release that supports Nginx OSS and Nginx+ enterprise edition.
 
-In the Loggin side, we have a new experimental __Kafka__ input plugin, enhanced performance for __Tail__, a new Windows __winevtlog__ that supports non-classic channels, new __OpenSearch__ output plugin
+In the Logging side, we have a new experimental __Kafka__ input plugin, enhanced performance for __Tail__, a new Windows __winevtlog__ that supports non-classic channels, new __OpenSearch__ output plugin
 and a hot new __Apache Arrow__ encoding support for our __S3__ output.
 
 Below you will find a more complete summary of the changes on this release.
@@ -67,7 +67,7 @@ Below you will find a more complete summary of the changes on this release.
    - event: new 'flb_event_' interface
    - network: properly react to being awoken due to a timeout
    - network: preserve addrlinfo list release address
-   - network: added dns result priorization option
+   - network: added dns result prioritization option
    - network: fixed async usage when not in a coroutine error
    - network: added dns context to hold active and drop lists
    - network: added async DNS UDP timeout management
@@ -85,7 +85,7 @@ Below you will find a more complete summary of the changes on this release.
    - tls: improve TLS handshake error message (#4561)
    - tls: Load system certificates on Windows
    - tls: openssl: fix error handling for OpenSSL API #4098 (#4100)
-   - installation: add script to install in one liner (#4740)
+   - installation: add script to install in one-liner (#4740)
    - plugin: add missing char cast
    - plugin: add support for config format
    - config_map: support deprecated property
@@ -99,7 +99,7 @@ Below you will find a more complete summary of the changes on this release.
    - upstream: avoid dns timeout null event injection (#4956)
    - upstream: replaced timeout wakeup mechanism
    - upstream: add new option 'net.connect_timeout_log_error' (#4473)
-   - upstream: added dns result priorization option
+   - upstream: added dns result prioritization option
    - upstream: added dns resolver configuration switch
    - upstream: detect shutdown and reduce log noise
    - sha512: use openssl implementation if available (#4303)
@@ -142,7 +142,7 @@ Below you will find a more complete summary of the changes on this release.
    - storage: added extra argument to flb_sched_timer_cb_create call
    - config: set default flush interval to '1'
    - config: support lowercase proxy environment variables
-   - config: added dns result priorization option
+   - config: added dns result prioritization option
    - config: increase coro stack size if it is less than pagesize (#3716) (#4434)
    - config: rename coro stack size define
    - config: added dns resolver configuration switch
@@ -187,127 +187,127 @@ Below you will find a more complete summary of the changes on this release.
    - lib: mbedtls: upgrade from v2.26 to v2.27
 
  - __Plugins__
-   - [Winlog (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/winlog/)
+   - [Winlog (Input)](https://docs.fluentbit.io/manual/1.9/pipeline/inputs/winlog/)
       - Support use_ansi config property (#4129)
-   - [Kafka (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/kafka/)
+   - [Kafka (Input)](https://docs.fluentbit.io/manual/1.9/pipeline/inputs/kafka/)
       - Initial implementation (experimental)
-   - [Nginx_Exporter_Metrics (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/nginx_exporter_metrics/)
+   - [Nginx Exporter Metrics (Input)](https://docs.fluentbit.io/manual/1.9/pipeline/inputs/nginx/)
       - Validate allocation and set proper null byte
       - New nginx metrics exporter (#3800)
-   - [Systemd (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/systemd/)
+   - [Systemd (Input)](https://docs.fluentbit.io/manual/1.9/pipeline/inputs/systemd/)
       - Add `lowercase` option (#4908)
       - Update to use config_map.
       - Skip broken entry
-   - [Prometheus_Scrape (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/prometheus_scrape/)
+   - [Prometheus Scrape (Input)](https://docs.fluentbit.io/manual/1.9/pipeline/inputs/prometheus-scrape-metrics/)
       - New prometheus scrape input plugin
-   - [Storage_Backlog (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/storage_backlog/)
+   - Storage_Backlog (Input)
       - Do not abort if chunk cannot be processed
       - Lookup chunk event type and use it when mapping the chunk
       - Properly handle when storage is not set
-   - [Tail (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/tail/)
+   - [Tail (Input)](https://docs.fluentbit.io/manual/1.9/pipeline/inputs/tail/)
       - On file rotation, remove entry from hash tables
       - Performance improvement on management of file list
       - Enhance handling of high number of static files (#3947)
-   - [Health (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/health/)
+   - [Health (Input)](https://docs.fluentbit.io/manual/1.9/pipeline/inputs/health/)
       - Add support for configmap. (#4907)
-   - [Forward (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/forward/)
+   - [Forward (Input)](https://docs.fluentbit.io/manual/1.9/pipeline/inputs/forward/)
       - Increase the buffer size to buffer_max_size
       - Fix handling of tcp connections on sigterm (#2610)
-   - [Proc (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/proc/)
+   - [Proc (Input)](https://docs.fluentbit.io/manual/1.9/pipeline/inputs/process/)
       - Fix possible free before allocation. (#5063)
       - Add support for configmap (#4902)
-   - [Nginx_Metrics (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/nginx_metrics/)
+   - [Nginx Exporter Metrics (Input)](https://docs.fluentbit.io/manual/1.9/pipeline/inputs/nginx/)
       - Add nginx plus metrics support (#4379)
-   - [Http (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/http/)
+   - [Http (Input)](https://docs.fluentbit.io/manual/1.9/pipeline/inputs/http/)
       - Memory leak correction (#4890)
       - Add lack of initialization and error handling (#4130)
-   - [Exec (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/exec/)
+   - [Exec (Input)](https://docs.fluentbit.io/manual/1.9/pipeline/inputs/exec/)
       - Don't eat last character of plugin output (#4496)
-   - [Node_Exporter_Metrics (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/node_exporter_metrics/)
+   - [Node Exporter Metrics (Input)](https://docs.fluentbit.io/manual/1.9/pipeline/inputs/node-exporter-metrics/)
       - Ensure zero with epsilon on double type factor
-   - [Windows_Exporter_Metrics (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/windows_exporter_metrics/)
+   - [Windows Exporter Metrics (Input)](https://docs.fluentbit.io/manual/1.9/pipeline/inputs/windows-exporter-metrics/)
       - New windows exporter metrics plugin
-   - [Opentelemetry (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/opentelemetry/)
+   - [Opentelemetry (Input)](https://docs.fluentbit.io/manual/1.9/pipeline/inputs/opentelemetry/)
       - Add experimental support for OpenTelemetry metrics (#5034)
-   - [Aws (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/aws/)
+   - [Aws Metadata (Filter)](https://docs.fluentbit.io/manual/1.9/pipeline/filters/aws-metadata/)
       - Expose metadata into main context env
       - Retrieve metadata on initialization
-   - [Lua (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/lua/)
+   - [Lua (Filter)](https://docs.fluentbit.io/manual/1.9/pipeline/filters/lua/)
       - Reimplement using mpack (#4524)
       - Extract code into flb_lua module
       - Calculate table size using table.maxn (#3433)
-   - [Multiline (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/multiline/)
+   - [Multiline (Filter)](https://docs.fluentbit.io/manual/1.9/pipeline/filters/multiline/)
       - Flush before return and new option 'debug_flush'
-   - [Checklist (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/checklist/)
+   - [Checklist (Filter)](https://docs.fluentbit.io/manual/1.9/pipeline/filters/checklist/)
       - New filter to flag records based on matching strings (#3869)
-   - [Nightfall (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/nightfall/)
+   - [Nightfall (Filter)](https://docs.fluentbit.io/manual/1.9/pipeline/filters/nightfall/)
       - Add `nightfall` filter (#4791)
-   - [Opensearch (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch/)
+   - [Opensearch (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/opensearch/)
       - Initial implementation of `opensearch` output plugin
-   - [Stdout (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/stdout/)
+   - [Standard Output (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/standard-output/)
       - Set 1 worker by default
-   - [TCP (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/tcp/)
+   - [TCP (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/tcp/)
       - Set 2 workers by default
-   - [Kafka (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/kafka/)
+   - [Kafka (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/kafka/)
       - Fix broken configuration (#4996)
-   - [Loki (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/loki/)
+   - [Loki (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/loki/)
       - Reduce accessor noise
       - Improve performance by removing record counter
       - Add comment about label key removal (#4539)
-   - [File (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/file/)
+   - [File (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/file/)
       - Set 1 worker by default
-      - Add option create output directory if does not exist (#4335)
+      - Add option create output directory if it does not exist (#4335)
       - Add explicit default format case (#4152)
-   - [Stackdriver (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver/)
+   - [Stackdriver (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/stackdriver/)
       - Set 2 workers by default
       - Add new metric `fluentbit_stackdriver_requests_total` (#2698)
-   - [Null (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/null/)
+   - [Null (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/null/)
       - Set 1 worker by default
       - Add `format` option, it supports `json_date_format` and `json_date_key` options. This option has
       been added for development and performance test purposes.
-   - [Elasticsearch (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/es/)
+   - [Elasticsearch (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/elasticsearch/)
       - Set 2 workers by default
-   - [Calyptia (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/calyptia/)
+   - Calyptia (Output)
       - Process and append aws metadata
-   - [S3 (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/s3/)
+   - [S3 (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/s3/)
       - Migrate to shared compression lib
       - Add default 1 workers
       - Migrate to performant base64 implementation
-   - [Kinesis_Firehose (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/kinesis_firehose/)
+   - [Kinesis Firehose (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/firehose/)
       - Integrate with shared compression lib
       - Add default 1 worker
-   - [Prometheus_Remote_Write (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/prometheus_remote_write/)
+   - [Prometheus Remote Write (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/prometheus-remote-write/)
       - Add custom headers support
-   - [Cloudwatch (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch/)
-      - Fix integer overflow on 32 bit systems when converting tv_sec to millis (#3640)
-   - [Forward (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/forward/)
+   - [Cloudwatch (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/cloudwatch/)
+      - Fix integer overflow on 32-bit systems when converting tv_sec to millis (#3640)
+   - [Forward (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/forward/)
       - Set 2 workers by default
-   - [HTTP (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/http/)
+   - [HTTP (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/http/)
       - Set 2 workers by default
-   - [Bigquery (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/bigquery/)
+   - [Bigquery (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/bigquery/)
       - Support aws auth via gcp workload identity federation (#4282)
       - Add `skipinvalidrows` and `ignoreunknownvalues` params (#4158)
-   - [Influxdb (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/influxdb/)
+   - [Influxdb (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/influxdb/)
       - Fix retry handling when http call fails
       - Enable http debug callbacks
       - Rename option `header` as `http_header`
       - Migrate to configmap and append new options
       - Add support for native metrics
-   - [Splunk (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/splunk/)
+   - [Splunk (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/splunk/)
       - Set 2 workers by default
       - New `http_debug_bad_request` option and auto buffer size
       - Auto-set http response buffer size
-   - [Prometheus_Remote_Write (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/prometheus_remote_write/)
+   - [Prometheus Remote Write (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/prometheus-remote-write/)
       - Reduce log noise for happy path (#4974)
-   - [Skywalking (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/skywalking/)
+   - [Skywalking (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/skywalking/)
       - Introduce apache skywalking output plugin (#3592)
-   - [Prometheus_Remote_Write (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/prometheus_remote_write/)
+   - [Prometheus Remote Write (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/prometheus-remote-write/)
       - Set 2 workers by default
-   - [Opentelemetry Metrics (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/opentelemetry/)
+   - [Opentelemetry Metrics (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/opentelemetry/)
       - Set default metrics uri to `/v1/metrics`
-   - [Prometheus_Exporter (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/prometheus_exporter/)
+   - [Prometheus Exporter (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/prometheus-exporter/)
       - Add new option `add_timestamp`, disabled by default
-   - [Kinesis_Streams (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/kinesis_streams/)
+   - [Kinesis Streams (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/kinesis/)
       - Add default 1 worker
       - Migrate to performant base64 implementation
 
@@ -315,7 +315,7 @@ Below you will find a more complete summary of the changes on this release.
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 * [Ramya Krishnamoorthy](https://github.com/krispraws)
 * [Leonardo Alminana](https://github.com/leonardo-albertovich)
@@ -330,7 +330,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.9/v1.9.1.md
+++ b/content/announcements/v1.9/v1.9.1.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.9.1'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
 url: "/announcements/v1.9.1/"
 release_date: 2022-03-25
 publishdate: 2022-03-25
@@ -31,21 +31,21 @@ latestVer: true
    - config: add new config format list
 
  - Plugins
-   - [Nightfall (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/nightfall/)
+   - [Nightfall (Filter)](https://docs.fluentbit.io/manual/1.9/pipeline/filters/nightfall/)
       - Fix for loop variable syntax (#5119)
       - Capitalize flag in cmakelists (#5107)
-   - [Kubernetes (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/kubernetes/)
+   - [Kubernetes (Filter)](https://docs.fluentbit.io/manual/1.9/pipeline/filters/kubernetes/)
       - Fix leak on journal mode when excluding records
-   - [Opensearch (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch/)
+   - [Opensearch (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/opensearch/)
       - Fix double free on index header (#5132)
-   - [Kafka (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/kafka/)
+   - [Kafka (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/kafka/)
       - Fix broken config map (#5097)
 
 {{< contributor-list >}}
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 - [Patrick Stephens](https://github.com/patrick-stephens)
 - [Eduardo Silva](https://github.com/edsiper)
@@ -59,7 +59,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.9/v1.9.2.md
+++ b/content/announcements/v1.9/v1.9.2.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.9.2'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
 url: "/announcements/v1.9.2/"
 release_date: 2022-04-08
 publishdate: 2022-04-08
@@ -24,25 +24,25 @@ latestVer: true
    - aws: extract initialization of aws_provider commonly used
    - aws: check AWS EC2 IMDSv2 client error
    - multiline: cri: Use non-greedy parsing for parsing time
-   - build: macos: create certfiticates from keychain on configure
+   - build: macOS: create certfiticates from keychain on configure
 
  - __Plugins__
-   - [Parser (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/parser/)
+   - [Parser (Filter)](https://docs.fluentbit.io/manual/1.9/pipeline/filters/parser/)
       - Mark `unescape_key` as a deprecated property
-   - [Grep (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/grep/)
+   - [Grep (Filter)](https://docs.fluentbit.io/manual/1.9/pipeline/filters/grep/)
       - Support config map(#5209)
-   - [Websocket (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/websocket/)
+   - [Websocket (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/websocket/)
       - Add missing json_date_ properties to config_map
-   - [Lib (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/lib/)
+   - Lib (Output)
       - Change windows-setup.cmake to use flb_out_lib (#5011)
-   - [S3 (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/s3/)
+   - [S3 (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/s3/)
       - Support content_type, storage_class when multipart upload enabled
       - Add storage_class support
-   - [HTTP (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/http/)
+   - [HTTP (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/http/)
       - Add sigv4 authentication options
-   - [Cloudwatch_Logs (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch_logs/)
+   - [Cloudwatch Logs (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/cloudwatch/)
       - Handle dataalreadyacceptedexception response
-   - [Stackdriver (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver/)
+   - [Stackdriver (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/stackdriver/)
       - Implement 502 status error for network exceptions
       - Implement new metric fluentbit_stackdriver_proc_records_total
 
@@ -50,7 +50,7 @@ latestVer: true
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 - [Matthew Fala](https://github.com/matthewfala)
 - [Eduardo Silva](https://github.com/edsiper)
@@ -67,7 +67,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.9/v1.9.3.md
+++ b/content/announcements/v1.9/v1.9.3.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.9.3'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
 url: "/announcements/v1.9.3/"
 release_date: 2022-04-08
 publishdate: 2022-04-08
@@ -36,44 +36,44 @@ latestVer: true
 
 
  - __Plugins__
-   - [Prometheus_Scrape (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/prometheus_scrape/)
+   - [Prometheus Scrape (Input)](https://docs.fluentbit.io/manual/1.9/pipeline/inputs/prometheus-scrape-metrics/)
       - Fix invalid type reference in log call format string (#5322)
-   - [Exec (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/exec/)
+   - [Exec (Input)](https://docs.fluentbit.io/manual/1.9/pipeline/inputs/exec/)
       - Fix using interval from config map (#5227)
-   - [Storage_Backlog (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/storage_backlog/)
+   - Storage_Backlog (Input)
       - Skip corrupted chunks
-   - [Tcp (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/tcp/)
+   - [Tcp (Input)](https://docs.fluentbit.io/manual/1.9/pipeline/inputs/tcp/)
       - Close server_fd on destroy
-   - [Docker (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/docker/)
+   - [Docker (Input)](https://docs.fluentbit.io/manual/1.9/pipeline/inputs/docker/)
       - Fix error handling if some resources not found (#5189)
       - Add missing include/exclude property
-   - [Nest (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/nest/)
+   - [Nest (Filter)](https://docs.fluentbit.io/manual/1.9/pipeline/filters/nest/)
       - Fix wildcard config to allow multiple entries (#5264)
       - Check if flb_strndup returns null (#5315)
-   - [Record_Modifier (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/record_modifier/)
+   - [Record Modifier (Filter)](https://docs.fluentbit.io/manual/1.9/pipeline/filters/record-modifier/)
       - Add error check for flb_strndup(#5103) (#5122)
-   - [Lua (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/lua/)
+   - [Lua (Filter)](https://docs.fluentbit.io/manual/1.9/pipeline/filters/lua/)
       - Add return for discarding all records (#5251) (#5271)
       - Add new option `code` to load script from a string
-   - [Multiline (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/multiline-stacktrace/)
+   - [Multiline (Filter)](https://docs.fluentbit.io/manual/1.9/pipeline/filters/multiline-stacktrace/)
       - Add fluentd log driver partial message support (#5285)
       - Implement buffered mode using in_emitter
-   - [Grep (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/grep/)
+   - [Grep (Filter)](https://docs.fluentbit.io/manual/1.9/pipeline/filters/grep/)
       - Check if flb_strndup returns null (#5316)
-   - [Stackdriver (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver/)
+   - [Stackdriver (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/stackdriver/)
       - Ensure url encoding for the oauth2 request, and send to the more modern endpoint. (#3198)
       - Add static labels defined in configuration (#5176)
-   - [Bigquery (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/bigquery/)
+   - [Bigquery (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/bigquery/)
       - Url-encode the oauth request body.
       - Switch to a more modern oauth2 token url.
-   - [Cloudwatch_Logs (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch/)
+   - [Cloudwatch Logs (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/cloudwatch/)
       - Only create log group if it does not already exist to prevent throttling
 
 {{< contributor-list >}}
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 - [Takahiro Yamashita](https://github.com/nokute78)
 - [David Korczynski](https://github.com/DavidKorczynski)
@@ -93,7 +93,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.9/v1.9.4.md
+++ b/content/announcements/v1.9/v1.9.4.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.9.4'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
 url: "/announcements/v1.9.4/"
 release_date: 2022-06-06
 publishdate: 2022-06-06
@@ -31,42 +31,42 @@ latestVer: true
    - pack: modify to determine how many JSON messages are OK(#5336)
 
  - __Plugins__
-   - [Forward (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/forward/)
+   - [Forward (Input)](https://docs.fluentbit.io/manual/1.9/pipeline/inputs/forward/)
       - Support unix_perm  (#5511)
-   - [Opentelemetry (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/opentelemetry/)
+   - [Opentelemetry (Input)](https://docs.fluentbit.io/manual/1.9/pipeline/inputs/opentelemetry/)
       - Fixed the event type so OpenTelemetry metrics are properly routed
-   - [Systemd (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/systemd/)
+   - [Systemd (Input)](https://docs.fluentbit.io/manual/1.9/pipeline/inputs/systemd/)
       - Don't insert rows if flb_sqldb_query fails
       - Fix 'db.sync' property (#5426)
-   - [Syslog (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/syslog/)
+   - [Syslog (Input)](https://docs.fluentbit.io/manual/1.9/pipeline/inputs/syslog/)
       - Don't release unix_path on exit
-   - [Lua (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/lua/)
+   - [Lua (Filter)](https://docs.fluentbit.io/manual/1.9/pipeline/filters/lua/)
       - Fix record split in mpack implementation
-   - [Kubernetes (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/kubernetes/)
+   - [Kubernetes (Filter)](https://docs.fluentbit.io/manual/1.9/pipeline/filters/kubernetes/)
       - Add new option `kube_token_ttl` (#4352) (#4487)
-   - [HTTP (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/http/)
+   - [HTTP (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/http/)
       - Implement "body_key" and "headers_key" options (#5439)
-   - [Kinesis_Firehose (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/kinesis_firehose/)
+   - [Kinesis Firehose (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/firehose/)
       - Add debug message to check batching
-   - [Syslog (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/syslog/)
+   - [Syslog (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/syslog/)
       - Add formatter callback
-   - [Stackdriver (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver/)
+   - [Stackdriver (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/stackdriver/)
       - Do not allocate metadata_server by config map
       - Free metadata_server when 'metadata_server' is not set
       - Initialize the metadata_server value to null
-   - [Azure (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/azure/)
+   - [Azure Log Analytics (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/azure/)
       - Fix typo which generates segv (#5379)
-   - [Cloudwatch_Logs (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch_logs/)
+   - [Cloudwatch Logs (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/cloudwatch/)
       - Add debug message to check payload size
       - Set 1 worker as default
-   - [Kinesis_Streams (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/kinesis_streams/)
+   - [Kinesis Streams (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/kinesis/)
       - Add debug message to check batching
 
 {{< contributor-list >}}
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 
 - [Takahiro Yamashita](https://github.com/nokute78)
@@ -86,7 +86,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.9/v1.9.5.md
+++ b/content/announcements/v1.9/v1.9.5.md
@@ -1,6 +1,6 @@
 ---
 title: 'v1.9.5'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
 url: "/announcements/v1.9.5/"
 release_date: 2022-06-22
 publishdate: 2022-06-22
@@ -27,18 +27,18 @@ latestVer: true
    - cmetrics: upgrade to v0.3.4
 
  - __Plugins__
-   - [Opentelemetry (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/opentelemetry/)
+   - [Opentelemetry (Input)](https://docs.fluentbit.io/manual/1.9/pipeline/inputs/opentelemetry/)
       - Add support for raw Traces
-   - [HTTP (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/http/)
+   - [HTTP (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/http/)
       - Add formatter function for testing
-   - [Tcp (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/tcp/)
+   - [Tcp (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/tcp/)
       - Add formatter function for testing
 
 {{< contributor-list >}}
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 
 - [Patrick Stephens](https://github.com/patrick-stephens)
@@ -54,7 +54,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.9/v1.9.6.md
+++ b/content/announcements/v1.9/v1.9.6.md
@@ -35,36 +35,36 @@ latestVer: true
    - c-ares: upgrade to v1.18.1
 
  - __Plugins__
-   - [Opentelemetry (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/opentelemetry/)
+   - [Opentelemetry (Input)](https://docs.fluentbit.io/manual/1.9/pipeline/inputs/opentelemetry/)
       - Change endpoints for metrics and traces and fix trace serialization
       - On closing connection, release channel
       - Set default OTLP/http port to `4318`
-   - [Netif (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/netif/)
+   - Netif (Input)
       - Add missing return type
-   - [Multiline (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/multiline/)
+   - [Multiline (Filter)](https://docs.fluentbit.io/manual/1.9/pipeline/filters/multiline/)
       - Use flb_time api to get timestamp in millisecond
-   - [Throttle (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/throttle/)
+   - [Throttle (Filter)](https://docs.fluentbit.io/manual/1.9/pipeline/filters/throttle/)
       - Add mutex to prevent race issue
       - Fixed use after free (#4792)
-   - [Modify (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/modify/)
+   - [Modify (Filter)](https://docs.fluentbit.io/manual/1.9/pipeline/filters/modify/)
       - Add error check for flb_strndup(#5103)
-   - [Expect (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/expect/)
+   - [Expect (Filter)](https://docs.fluentbit.io/manual/1.9/pipeline/filters/expect/)
       - Support 'result_key' property
-   - [Kubernetes (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/kubernetes/)
+   - [Kubernetes (Filter)](https://docs.fluentbit.io/manual/1.9/pipeline/filters/kubernetes/)
       - Add ability to change `kubelet_host`
-   - [Datadog (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/datadog/)
+   - [Datadog (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/datadog/)
       - Switch noisy info level to debug level (#5596)
-   - [Stdout (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/stdout/)
+   - [Stdout (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/standard-output/)
       - Handle error case (#5603)
-   - [S3 (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/s3/)
+   - [S3 (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/s3/)
       - Update s3 putobjectsize to 1gb (#5688)
-   - [Syslog (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/syslog/)
+   - [Syslog (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/syslog/)
       - Fix TLS handling in config and code logic (fix #5643) (#5646)
-   - [Forward (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/forward/)
+   - [Forward (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/forward/)
       - Support `unix_path`
-   - [Cloudwatch_Logs (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch_logs/)
+   - [Cloudwatch Logs (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/cloudwatch/)
       - Support for record_accessor for templating stream and group names
-   - [Datadog (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/datadog/))
+   - [Datadog (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/datadog/))
       - do not append api-key to uri
       - support v2 endpoint
 
@@ -72,7 +72,7 @@ latestVer: true
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 - [Eduardo Silva](https://github.com/edsiper)
 - weijian zhang
@@ -93,7 +93,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.9/v1.9.7.md
+++ b/content/announcements/v1.9/v1.9.7.md
@@ -25,18 +25,18 @@ latestVer: true
    - aws_util: set AWS Fluent Bit user agent based on environment
 
  - __Plugins__
-   - [Tail (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/tail/)
+   - [Tail (Input)](https://docs.fluentbit.io/manual/1.9/pipeline/inputs/tail/)
       - Added event based file ingestion batch limit
-   - [S3 (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/s3/)
+   - [S3 (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/s3/)
       - Add gzip compression support for multipart uploads
-   - [Cloudwatch_Logs (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch_logs/)
+   - [Cloudwatch Logs (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/cloudwatch/)
       - Skip counting empty events
 
 {{< contributor-list >}}
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 - [Leonardo Alminana](https://github.com/leonardo-albertovich)
 - [Hiroshi Hatake](https://github.com/cosmo0920)
@@ -50,7 +50,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.9/v1.9.8.md
+++ b/content/announcements/v1.9/v1.9.8.md
@@ -29,21 +29,21 @@ latestVer: true
     - cmetrics: upgrade from v0.3.5 to v0.3.6
 
  - __Plugins__
-   - [Tail (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/tail/)
+   - [Tail (Input)](https://docs.fluentbit.io/manual/1.9/pipeline/inputs/tail/)
       - Add missed argument processed_bytes
       - Fix path_key when the file is rotated (#5829)
-   - [Stackdriver (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver/)
+   - [Stackdriver (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/stackdriver/)
       - Add name label to the metrics emitted
-   - [Kinesis_Firehose (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/kinesis_firehose/)
+   - [Kinesis_Firehose (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/firehose/)
       - Refactoring to fix windows build
-   - [Kafka (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/kafka/)
+   - [Kafka (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/kafka/)
       - Add support to force flush when shutdown. (fluent#5593)
 
 {{< contributor-list >}}
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 - [Alexs L](https://github.com/sashashura)
 - [Eduardo Silva](https://github.com/edsiper)
@@ -60,7 +60,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)

--- a/content/announcements/v1.9/v1.9.9.md
+++ b/content/announcements/v1.9/v1.9.9.md
@@ -34,16 +34,16 @@ latestVer: true
    - chunkio: upgrade to v1.3.0
 
  - __Plugins__
-   - [Opensearch (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch/)
+   - [Opensearch (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/opensearch/)
       - Fix trace_error truncating the response
-   - [Elasticsearch (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/es/)
+   - [Elasticsearch (Output)](https://docs.fluentbit.io/manual/1.9/pipeline/outputs/elasticsearch/)
       - Fix trace_error truncating the response
 
 {{< contributor-list >}}
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 
 - [Takahiro Yamashita](https://github.com/nokute78)
@@ -56,7 +56,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)
 * Mailing list: [https://groups.google.com/forum/#!forum/fluent-bit](https://groups.google.com/forum/#!forum/fluent-bit)


### PR DESCRIPTION
Fixes for release docs plugin links for Fluent Bit v1.6 through v1.9. Part of issue #30.