### PR TITLE
Fixes for release docs plugin links for Fluent Bit v2.0 through v2.2. Part of issue #30. 

### DIFF
--- a/content/announcements/v2.0/v2.0.0.md
+++ b/content/announcements/v2.0/v2.0.0.md
@@ -1,6 +1,6 @@
 ---
 title: 'v2.0.0'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
 url: "/announcements/v2.0.0/"
 release_date: 2022-10-25
 publishdate: 2022-10-25
@@ -17,7 +17,7 @@ latestVer: true
 
 For people upgrading from previous versions you **must read** the Upgrading Notes section of our documentation:
 
-[https://docs.fluentbit.io/manual/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
+[https://docs.fluentbit.io/manual/2.0/installation/upgrade_notes](https://docs.fluentbit.io/manual/2.0/installation/upgrade_notes)
 
 #### Introduction
 
@@ -86,11 +86,11 @@ In Fluent Bit, we are announcing full support for OpenTelemetry, where now we ca
 
 **OpenTelemetry input plugin**
 
-This [new plugin](https://docs.fluentbit.io/manual/pipeline/inputs/opentelemetry), can receive OpenTelemetry Logs, Metrics and Traces, all of them are supported through this new implementation that allow easily integration with applications instrumented with OpenTelemetry SDKs.
+This [new plugin](https://docs.fluentbit.io/manual/2.0/pipeline/inputs/opentelemetry), can receive OpenTelemetry Logs, Metrics and Traces, all of them are supported through this new implementation that allow easily integration with applications instrumented with OpenTelemetry SDKs.
 
 **OpenTelemetry output plugin**
 
-This [new plugin](https://docs.fluentbit.io/manual/pipeline/outputs/opentelemetry) allows to deliver any Log, Metric or Trace collected to a remote endpoint that supports OpenTelemetry, it could be any vendor platform or the OpenTelemetry collector.
+This [new plugin](https://docs.fluentbit.io/manual/2.0/pipeline/outputs/opentelemetry) allows to deliver any Log, Metric or Trace collected to a remote endpoint that supports OpenTelemetry, it could be any vendor platform or the OpenTelemetry collector.
 
 #### Performance
 
@@ -167,11 +167,11 @@ TAP is a very advanced functionality that allows inspecting the data that flows 
 
 More details about this functionality can be seen here in the official documentation:
 
-- [https://docs.fluentbit.io/manual/administration/troubleshooting#tap-functionality](https://docs.fluentbit.io/manual/administration/troubleshooting#tap-functionality)
+- [https://docs.fluentbit.io/manual/2.0/administration/troubleshooting#tap-functionality](https://docs.fluentbit.io/manual/2.0/administration/troubleshooting#tap-functionality)
 
 #### Internal Metrics
 
-Historically, a common way to extract internal metrics from Fluent Bit has been by enabling the built-in [HTTP service](https://docs.fluentbit.io/manual/administration/monitoring#http-server "Fluent Bit Monitoring - HTTP Server") which exposes the following endpoints in the [REST API](https://docs.fluentbit.io/manual/administration/monitoring#rest-api-interface "Fluent Bit Monitoring REST API"):
+Historically, a common way to extract internal metrics from Fluent Bit has been by enabling the built-in [HTTP service](https://docs.fluentbit.io/manual/2.0/administration/monitoring#http-server "Fluent Bit Monitoring - HTTP Server") which exposes the following endpoints in the [REST API](https://docs.fluentbit.io/manual/2.0/administration/monitoring#rest-api-interface "Fluent Bit Monitoring REST API"):
 
 | Endpoint                   | Description                                                  |
 | -------------------------- | ------------------------------------------------------------ |
@@ -181,7 +181,7 @@ Historically, a common way to extract internal metrics from Fluent Bit has been 
 
 One of the restrictions of this interface, is that those metrics are not part of the pipeline, which means, you can only access them remotely. But what about if you want to _send_ your metrics to a destination like Prometheus, InfluxDB or other ?.
 
-During the release cycle of the previous series of Fluent Bit, we introduced a new mechanism to collect and process internal metrics through a new input plugin plugin called  `fluentbit_metrics`. This new mechanism allows to expose or send the metrics to a destination in many ways like:
+During the release cycle of the previous series of Fluent Bit, we introduced a new mechanism to collect and process internal metrics through a new input plugin called  `fluentbit_metrics`. This new mechanism allows to expose or send the metrics to a destination in many ways like:
 
 <br>
 
@@ -214,7 +214,7 @@ Starting from Fluent Bit v2, `fluentbit_metrics` exposes seven new metrics for t
 
 #### Memory Ring buffer
 
-The memory-ring-buffer mechanism is an optional buffering strategy for input plugins that relies only in memory. When this is enabled, the chunks management behaves as a ring buffer of a fixed size were setting up mem_buf_limit is mandatory to specify that limit.
+The memory-ring-buffer mechanism is an optional buffering strategy for input plugins that relies on only in memory. When this is enabled, the chunks management behaves as a ring buffer of a fixed size were setting up mem_buf_limit is mandatory to specify that limit.
 
 When the chunks are enqueued, and mem_buf_limit is reached, instead of pausing the input plugin as normally would happen with the default memory strategy, this new mechanism removes the oldest Chunks from the queue until to make sure there is enough space for the new incoming data.
 
@@ -283,13 +283,13 @@ We encourage users to move to Fluent Bit v2 and adopt the new package name. Note
 {{< contributor-list >}}
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 {{< /contributor-list >}}
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Github: [http://github.com/fluent/fluent-bit](https://github.com/fluent/fluent-bit)
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)

--- a/content/announcements/v2.0/v2.0.1.md
+++ b/content/announcements/v2.0/v2.0.1.md
@@ -1,6 +1,6 @@
 ---
 title: 'v2.0.1'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
 url: "/announcements/v2.0.1/"
 release_date: 2022-10-25
 publishdate: 2022-10-25
@@ -20,7 +20,7 @@ release notes as part of v2
 
 For people upgrading from previous versions you **must read** the Upgrading Notes section of our documentation:
 
-[https://docs.fluentbit.io/manual/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
+[https://docs.fluentbit.io/manual/2.0/installation/upgrade_notes](https://docs.fluentbit.io/manual/2.0/installation/upgrade_notes)
 
 #### Introduction
 
@@ -89,11 +89,11 @@ In Fluent Bit, we are announcing full support for OpenTelemetry, where now we ca
 
 **OpenTelemetry input plugin**
 
-This [new plugin](https://docs.fluentbit.io/manual/pipeline/inputs/opentelemetry), can receive OpenTelemetry Logs, Metrics and Traces, all of them are supported through this new implementation that allow easily integration with applications instrumented with OpenTelemetry SDKs.
+This [new plugin](https://docs.fluentbit.io/manual/2.0/pipeline/inputs/opentelemetry), can receive OpenTelemetry Logs, Metrics and Traces, all of them are supported through this new implementation that allow easily integration with applications instrumented with OpenTelemetry SDKs.
 
 **OpenTelemetry output plugin**
 
-This [new plugin](https://docs.fluentbit.io/manual/pipeline/outputs/opentelemetry) allows to deliver any Log, Metric or Trace collected to a remote endpoint that supports OpenTelemetry, it could be any vendor platform or the OpenTelemetry collector.
+This [new plugin](https://docs.fluentbit.io/manual/2.0/pipeline/outputs/opentelemetry) allows to deliver any Log, Metric or Trace collected to a remote endpoint that supports OpenTelemetry, it could be any vendor platform or the OpenTelemetry collector.
 
 #### Performance
 
@@ -170,11 +170,11 @@ TAP is a very advanced functionality that allows inspecting the data that flows 
 
 More details about this functionality can be seen here in the official documentation:
 
-- [https://docs.fluentbit.io/manual/administration/troubleshooting#tap-functionality](https://docs.fluentbit.io/manual/administration/troubleshooting#tap-functionality)
+- [https://docs.fluentbit.io/manual/2.0/administration/troubleshooting#tap-functionality](https://docs.fluentbit.io/manual/2.0/administration/troubleshooting#tap-functionality)
 
 #### Internal Metrics
 
-Historically, a common way to extract internal metrics from Fluent Bit has been by enabling the built-in [HTTP service](https://docs.fluentbit.io/manual/administration/monitoring#http-server "Fluent Bit Monitoring - HTTP Server") which exposes the following endpoints in the [REST API](https://docs.fluentbit.io/manual/administration/monitoring#rest-api-interface "Fluent Bit Monitoring REST API"):
+Historically, a common way to extract internal metrics from Fluent Bit has been by enabling the built-in [HTTP service](https://docs.fluentbit.io/manual/2.0/administration/monitoring#http-server "Fluent Bit Monitoring - HTTP Server") which exposes the following endpoints in the [REST API](https://docs.fluentbit.io/manual/2.0/administration/monitoring#rest-api-interface "Fluent Bit Monitoring REST API"):
 
 | Endpoint                   | Description                                                  |
 | -------------------------- | ------------------------------------------------------------ |
@@ -184,7 +184,7 @@ Historically, a common way to extract internal metrics from Fluent Bit has been 
 
 One of the restrictions of this interface, is that those metrics are not part of the pipeline, which means, you can only access them remotely. But what about if you want to _send_ your metrics to a destination like Prometheus, InfluxDB or other ?.
 
-During the release cycle of the previous series of Fluent Bit, we introduced a new mechanism to collect and process internal metrics through a new input plugin plugin called  `fluentbit_metrics`. This new mechanism allows to expose or send the metrics to a destination in many ways like:
+During the release cycle of the previous series of Fluent Bit, we introduced a new mechanism to collect and process internal metrics through a new input plugin called  `fluentbit_metrics`. This new mechanism allows to expose or send the metrics to a destination in many ways like:
 
 <br>
 
@@ -217,7 +217,7 @@ Starting from Fluent Bit v2, `fluentbit_metrics` exposes seven new metrics for t
 
 #### Memory Ring buffer
 
-The memory-ring-buffer mechanism is an optional buffering strategy for input plugins that relies only in memory. When this is enabled, the chunks management behaves as a ring buffer of a fixed size were setting up mem_buf_limit is mandatory to specify that limit.
+The memory-ring-buffer mechanism is an optional buffering strategy for input plugins that relies on only in memory. When this is enabled, the chunks management behaves as a ring buffer of a fixed size were setting up mem_buf_limit is mandatory to specify that limit.
 
 When the chunks are enqueued, and mem_buf_limit is reached, instead of pausing the input plugin as normally would happen with the default memory strategy, this new mechanism removes the oldest Chunks from the queue until to make sure there is enough space for the new incoming data.
 
@@ -286,13 +286,13 @@ We encourage users to move to Fluent Bit v2 and adopt the new package name. Note
 {{< contributor-list >}}
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 {{< /contributor-list >}}
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Github: [http://github.com/fluent/fluent-bit](https://github.com/fluent/fluent-bit)
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)

--- a/content/announcements/v2.0/v2.0.10.md
+++ b/content/announcements/v2.0/v2.0.10.md
@@ -1,6 +1,6 @@
 ---
 title: 'v2.0.10'
-description: 'We provide the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
+description: 'We provide the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
 url: "/announcements/v2.0.10/"
 release_date: 2023-02-06
 publishdate: 2023-02-06
@@ -35,46 +35,46 @@ Fluent Bit v2.0 is the start of the new stable series of the project. During the
    - input: removed unnecessary code from flb_input_downstream_set
 
  - Plugins
-   - [UDP (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/udp/)
+   - UDP (Input)
       - Fixed event loop bugs in threaded mode
-   - [HTTP (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/http/)
+   - [HTTP (Input)](https://docs.fluentbit.io/manual/2.0/pipeline/inputs/http/)
       - Fixed event loop bugs in threaded mode
-   - [Syslog (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/syslog/)
+   - [Syslog (Input)](https://docs.fluentbit.io/manual/2.0/pipeline/inputs/syslog/)
       - Fixed event loop bugs in threaded mode
-   - [Winevtlog (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/winevtlog/)
+   - [Winevtlog (Input)](https://docs.fluentbit.io/manual/2.0/pipeline/inputs/windows-event-log-winevtlog/)
       - add missing break statement
-   - [MQTT (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/mqtt/)
+   - [MQTT (Input)](https://docs.fluentbit.io/manual/2.0/pipeline/inputs/mqtt/)
       - Fixed event loop bugs in threaded mode
-   - [Tcp (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/tcp/)
+   - [Tcp (Input)](https://docs.fluentbit.io/manual/2.0/pipeline/inputs/tcp/)
       - Fixed event loop bugs in threaded mode
-   - [Opentelemetry (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/opentelemetry/)
+   - [Opentelemetry (Input)](https://docs.fluentbit.io/manual/2.0/pipeline/inputs/opentelemetry/)
       - Uninitialized variable usage fix
       - Fixed event loop bugs in threaded mode
-   - [Unix_Socket (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/unix_socket/)
+   - Unix_Socket (Input)
       - Fixed event loop bugs in threaded mode
-   - [Tail (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/tail/)
+   - [Tail (Input)](https://docs.fluentbit.io/manual/2.0/pipeline/inputs/tail/)
       - Fixed argument order that caused a segfault in issue 6797
-   - [Elasticsearch (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/elasticsearch/)
+   - [Elasticsearch (Input)](https://docs.fluentbit.io/manual/2.0/pipeline/inputs/elasticsearch/)
       - Fixed event loop bugs in threaded mode
       - Implement a plugin for elasticsearch bulk api (for 2.0) (#6685)
-   - [Forward (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/forward/)
+   - [Forward (Input)](https://docs.fluentbit.io/manual/2.0/pipeline/inputs/forward/)
       - Fixed event loop bugs in threaded mode
-   - [Pgsql (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/pgsql/)
+   - [PostgreSQL (Output)](https://docs.fluentbit.io/manual/2.0/pipeline/outputs/postgresql/)
       - Add new `connection_options` property
-   - [S3 (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/s3/)
+   - [S3 (Output)](https://docs.fluentbit.io/manual/2.0/pipeline/outputs/s3/)
       - Backport of pr 6988
-   - [Loki (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/loki/)
+   - [Loki (Output)](https://docs.fluentbit.io/manual/2.0/pipeline/outputs/loki/)
       - Pr 6931 backport
       - Add missing flb_sds_cat for float value
       - Use flb_sds_pointer to propagate updated pointer.
-   - [Opentelemetry (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/opentelemetry/)
+   - [Opentelemetry (Output)](https://docs.fluentbit.io/manual/2.0/pipeline/outputs/opentelemetry/)
       - Fixed bugs that caused issue 6899
       - Fixed memory corruptions and double frees
 
 {{< contributor-list >}}
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 - [Jonathan Gonzalez V](https://github.com/sxd)
 - [Jeff Erbrecht](https://github.com/jefferbrecht)
@@ -87,7 +87,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Github: [http://github.com/fluent/fluent-bit](https://github.com/fluent/fluent-bit)
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)

--- a/content/announcements/v2.0/v2.0.11.md
+++ b/content/announcements/v2.0/v2.0.11.md
@@ -1,6 +1,6 @@
 ---
 title: 'v2.0.11'
-description: 'We provide the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
+description: 'We provide the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
 url: "/announcements/v2.0.11/"
 release_date: 2023-02-06
 publishdate: 2023-02-06
@@ -38,7 +38,7 @@ Fluent Bit v2.0 is the start of the new stable series of the project. During the
 {{< contributor-list >}}
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 
 - [Pat](https://github.com/patrick-stephens)
@@ -48,7 +48,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Github: [http://github.com/fluent/fluent-bit](https://github.com/fluent/fluent-bit)
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)

--- a/content/announcements/v2.0/v2.0.2.md
+++ b/content/announcements/v2.0/v2.0.2.md
@@ -1,6 +1,6 @@
 ---
 title: 'v2.0.2'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
 url: "/announcements/v2.0.2/"
 release_date: 2022-10-27
 publishdate: 2022-10-27
@@ -21,7 +21,7 @@ BSD and OSX. We are proud to announce the availability of **Fluent Bit v2.0.2**.
 
 For people upgrading from previous versions you **must read** the Upgrading Notes section of our documentation:
 
-[https://docs.fluentbit.io/manual/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
+[https://docs.fluentbit.io/manual/2.0/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
 
 #### Introduction
 
@@ -90,11 +90,11 @@ In Fluent Bit, we are announcing full support for OpenTelemetry, where now we ca
 
 **OpenTelemetry input plugin**
 
-This [new plugin](https://docs.fluentbit.io/manual/pipeline/inputs/opentelemetry), can receive OpenTelemetry Logs, Metrics and Traces, all of them are supported through this new implementation that allow easily integration with applications instrumented with OpenTelemetry SDKs.
+This [new plugin](https://docs.fluentbit.io/manual/2.0/pipeline/inputs/opentelemetry), can receive OpenTelemetry Logs, Metrics and Traces, all of them are supported through this new implementation that allow easily integration with applications instrumented with OpenTelemetry SDKs.
 
 **OpenTelemetry output plugin**
 
-This [new plugin](https://docs.fluentbit.io/manual/pipeline/outputs/opentelemetry) allows to deliver any Log, Metric or Trace collected to a remote endpoint that supports OpenTelemetry, it could be any vendor platform or the OpenTelemetry collector.
+This [new plugin](https://docs.fluentbit.io/manual/2.0/pipeline/outputs/opentelemetry) allows to deliver any Log, Metric or Trace collected to a remote endpoint that supports OpenTelemetry, it could be any vendor platform or the OpenTelemetry collector.
 
 #### Performance
 
@@ -171,11 +171,11 @@ TAP is a very advanced functionality that allows inspecting the data that flows 
 
 More details about this functionality can be seen here in the official documentation:
 
-- [https://docs.fluentbit.io/manual/administration/troubleshooting#tap-functionality](https://docs.fluentbit.io/manual/administration/troubleshooting#tap-functionality)
+- [https://docs.fluentbit.io/manual/2.0/administration/troubleshooting#tap-functionality](https://docs.fluentbit.io/manual/2.0/administration/troubleshooting#tap-functionality)
 
 #### Internal Metrics
 
-Historically, a common way to extract internal metrics from Fluent Bit has been by enabling the built-in [HTTP service](https://docs.fluentbit.io/manual/administration/monitoring#http-server "Fluent Bit Monitoring - HTTP Server") which exposes the following endpoints in the [REST API](https://docs.fluentbit.io/manual/administration/monitoring#rest-api-interface "Fluent Bit Monitoring REST API"):
+Historically, a common way to extract internal metrics from Fluent Bit has been by enabling the built-in [HTTP service](https://docs.fluentbit.io/manual/2.0/administration/monitoring#http-server "Fluent Bit Monitoring - HTTP Server") which exposes the following endpoints in the [REST API](https://docs.fluentbit.io/manual/2.0/administration/monitoring#rest-api-interface "Fluent Bit Monitoring REST API"):
 
 | Endpoint                   | Description                                                  |
 | -------------------------- | ------------------------------------------------------------ |
@@ -185,7 +185,7 @@ Historically, a common way to extract internal metrics from Fluent Bit has been 
 
 One of the restrictions of this interface, is that those metrics are not part of the pipeline, which means, you can only access them remotely. But what about if you want to _send_ your metrics to a destination like Prometheus, InfluxDB or other ?.
 
-During the release cycle of the previous series of Fluent Bit, we introduced a new mechanism to collect and process internal metrics through a new input plugin plugin called  `fluentbit_metrics`. This new mechanism allows to expose or send the metrics to a destination in many ways like:
+During the release cycle of the previous series of Fluent Bit, we introduced a new mechanism to collect and process internal metrics through a new input plugin called  `fluentbit_metrics`. This new mechanism allows to expose or send the metrics to a destination in many ways like:
 
 <br>
 
@@ -218,7 +218,7 @@ Starting from Fluent Bit v2, `fluentbit_metrics` exposes seven new metrics for t
 
 #### Memory Ring buffer
 
-The memory-ring-buffer mechanism is an optional buffering strategy for input plugins that relies only in memory. When this is enabled, the chunks management behaves as a ring buffer of a fixed size were setting up mem_buf_limit is mandatory to specify that limit.
+The memory-ring-buffer mechanism is an optional buffering strategy for input plugins that relies on only in memory. When this is enabled, the chunks management behaves as a ring buffer of a fixed size were setting up mem_buf_limit is mandatory to specify that limit.
 
 When the chunks are enqueued, and mem_buf_limit is reached, instead of pausing the input plugin as normally would happen with the default memory strategy, this new mechanism removes the oldest Chunks from the queue until to make sure there is enough space for the new incoming data.
 
@@ -287,13 +287,13 @@ We encourage users to move to Fluent Bit v2 and adopt the new package name. Note
 {{< contributor-list >}}
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 {{< /contributor-list >}}
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Github: [http://github.com/fluent/fluent-bit](https://github.com/fluent/fluent-bit)
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)

--- a/content/announcements/v2.0/v2.0.3.md
+++ b/content/announcements/v2.0/v2.0.3.md
@@ -1,6 +1,6 @@
 ---
 title: 'v2.0.3'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
 url: "/announcements/v2.0.3/"
 release_date: 2022-10-28
 publishdate: 2022-10-28
@@ -34,15 +34,15 @@ Fluent Bit v2.0 is the start of the new stable series of the project. During the
    - tests: internal: cf_fluentbit: add test case for #6281
 
  - Plugins
-   - [Winevtlog (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/winevtlog/)
+   - [Winevtlog (Input)](https://docs.fluentbit.io/manual/2.0/pipeline/inputs/windows-event-log-winevtlog/)
       - Fix ignoring non-existent channel handling
-   - [Forward (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/forward/)
+   - [Forward (Output)](https://docs.fluentbit.io/manual/2.0/pipeline/outputs/forward/)
       - Put chunk key as the first key of the option map
 
 {{< contributor-list >}}
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 - [Hiroshi Hatake](https://github.com/cosmo0920)
 - [Takahiro Yamashita](https://github.com/nokute78)
@@ -52,7 +52,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Github: [http://github.com/fluent/fluent-bit](https://github.com/fluent/fluent-bit)
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)

--- a/content/announcements/v2.0/v2.0.4.md
+++ b/content/announcements/v2.0/v2.0.4.md
@@ -1,6 +1,6 @@
 ---
 title: 'v2.0.4'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
 url: "/announcements/v2.0.4/"
 release_date: 2022-11-08
 publishdate: 2022-11-08
@@ -52,20 +52,20 @@ Fluent Bit v2.0 is the start of the new stable series of the project. During the
 <br>
 
  - Plugins
-   - [Opentelemetry (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/opentelemetry/)
+   - [Opentelemetry (Output)](https://docs.fluentbit.io/manual/2.0/pipeline/outputs/opentelemetry/)
       - Upload log as object instead of json string
       - Increase batch size for logs export
-   - [Forward (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/forward/)
+   - [Forward (Output)](https://docs.fluentbit.io/manual/2.0/pipeline/outputs/forward/)
       - Introduce `fluentd_compat` option for sending Fluentd compatible payloads
       - Make forwardable for msgpack payloads of ctraces and cmetrics
-   - [Opensearch (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch/)
+   - [Opensearch (Output)](https://docs.fluentbit.io/manual/2.0/pipeline/outputs/opensearch/)
       - Support dynamic index with types
       - Add record accessor support for `index` property
 
 {{< contributor-list >}}
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 - [Phillip Whelan](https://github.com/pwhelan)
 - [Hiroshi Hatake](https://github.com/cosmo0920)
@@ -82,7 +82,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Github: [http://github.com/fluent/fluent-bit](https://github.com/fluent/fluent-bit)
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)

--- a/content/announcements/v2.0/v2.0.5.md
+++ b/content/announcements/v2.0/v2.0.5.md
@@ -1,6 +1,6 @@
 ---
 title: 'v2.0.5'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
 url: "/announcements/v2.0.5/"
 release_date: 2022-11-11
 publishdate: 2022-11-11
@@ -47,25 +47,25 @@ Fluent Bit v2.0 is the start of the new stable series of the project. During the
 <br>
 
  - Plugins
-   - [Nginx_Exporter_Metrics (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/nginx_exporter_metrics/)
+   - [NGINX Exporter Metrics (Input)](https://docs.fluentbit.io/manual/2.0/pipeline/inputs/nginx/)
       - Enable scraping of tls endpoints.
       - Fix vmstat metrics as counter metrics (#6302)
-   - [Tail (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/tail/)
+   - [Tail (Input)](https://docs.fluentbit.io/manual/2.0/pipeline/inputs/tail/)
       - Fix st_mtime timestamp format in Windows (#6291)
-   - [Health (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/health/)
+   - [Health (Input)](https://docs.fluentbit.io/manual/2.0/pipeline/inputs/health/)
       - Enabled optional TLS.
-   - [Cpu (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/cpu/)
+   - [Cpu (Input)](https://docs.fluentbit.io/manual/2.0/pipeline/inputs/cpu-metrics/)
       - Fix pointer to v_cpuid (#6238)
-   - [Prometheus_Scrape (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/prometheus_scrape/)
+   - [Prometheus Scrape Metrics (Input)](https://docs.fluentbit.io/manual/2.0/pipeline/inputs/prometheus-scrape-metrics/)
       - Enable scraping of TLS endpoints.
-   - [ECS (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/ecs/)
+   - [ECS Metadata (Filter)](https://docs.fluentbit.io/manual/2.0/pipeline/filters/ecs-metadata/)
       - Reduce error/warn messages when the filter processes logs not from a task
       - Make metadata api host and port configurable
 
 {{< contributor-list >}}
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 - [Tobias Nießen](https://github.com/tniessen)
 - [Wesley Pettit](https://github.com/PettitWesley)
@@ -84,7 +84,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Github: [http://github.com/fluent/fluent-bit](https://github.com/fluent/fluent-bit)
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)

--- a/content/announcements/v2.0/v2.0.6.md
+++ b/content/announcements/v2.0/v2.0.6.md
@@ -1,6 +1,6 @@
 ---
 title: 'v2.0.6'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
 url: "/announcements/v2.0.6/"
 release_date: 2022-11-22
 publishdate: 2022-11-22
@@ -48,25 +48,25 @@ Fluent Bit v2.0 is the start of the new stable series of the project. During the
 <br>
 
  - Plugins
-   - [Tail (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/tail/)
+   - [Tail (Input)](https://docs.fluentbit.io/manual/2.0/pipeline/inputs/tail/)
       - Add a lasterror to errno conversion layer.
-   - [Tcp (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/tcp/)
+   - [Tcp (Input)](https://docs.fluentbit.io/manual/2.0/pipeline/inputs/tcp/)
       - User friendly warn message for skipping records (#6062)
-   - [Record_Modifier (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/record_modifier/)
+   - [Record_Modifier (Filter)](https://docs.fluentbit.io/manual/2.0/pipeline/filters/record_modifier/)
       - Support `uuid_key`
-   - [Forward (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/forward/)
+   - [Forward (Output)](https://docs.fluentbit.io/manual/2.0/pipeline/outputs/forward/)
       - Fix concurrency issue when operating in Unix domain socket mode
-   - [Datadog (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/datadog/)
+   - [Datadog (Output)](https://docs.fluentbit.io/manual/2.0/pipeline/outputs/datadog/)
       - Fix/add error handling for all flb_sds calls (#5930)
-   - [OpenTelemetry (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/opentelemetry/)
+   - [OpenTelemetry (Output)](https://docs.fluentbit.io/manual/2.0/pipeline/outputs/opentelemetry/)
       - Add support for gzip compression (#6232)
-   - [Elasticsearch (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/es/)
+   - [Elasticsearch (Output)](https://docs.fluentbit.io/manual/2.0/pipeline/outputs/elasticsearch/)
       - Fix bulk buffer overrun
 
 {{< contributor-list >}}
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 - [Takahiro Yamashita](https://github.com/nokute78)
 - [Matthew Fala](https://github.com/matthewfala)
@@ -85,7 +85,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Github: [http://github.com/fluent/fluent-bit](https://github.com/fluent/fluent-bit)
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)

--- a/content/announcements/v2.0/v2.0.7.md
+++ b/content/announcements/v2.0/v2.0.7.md
@@ -1,6 +1,6 @@
 ---
 title: 'v2.0.7'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
 url: "/announcements/v2.0.7/"
 release_date: 2022-12-19
 publishdate: 2022-12-19
@@ -32,7 +32,7 @@ Fluent Bit v2.0 is the start of the new stable series of the project. During the
  - Core
    - bin: fix handling of buffer for text helper
    - tls: openssl: add SSL_ERROR_SYSCALL case (#6489)
-   - stream: fixed an condition that caused concurrency issues
+   - stream: fixed a condition that caused concurrency issues
    - parser: logfmt: optionally reject messages that have keys without values
    - parser: fix potential overflow
    - aws: util: extra_user_agent is always type flb_sds_t
@@ -53,41 +53,41 @@ Fluent Bit v2.0 is the start of the new stable series of the project. During the
 <br>
 
  - Plugins
-   - [Syslog (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/syslog/)
+   - [Syslog (Input)](https://docs.fluentbit.io/manual/2.0/pipeline/inputs/syslog/)
       - Rename new option to 'raw_message_key' and other adjustments
       - Added an option to append the raw message to the log record under a specific key.
-   - [Tail (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/tail/)
+   - [Tail (Input)](https://docs.fluentbit.io/manual/2.0/pipeline/inputs/tail/)
       - Remove extra fstat() syscall and remove unused function
-   - [Windows_Exporter_Metrics (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/windows_exporter_metrics/)
+   - [Windows Exporter Metrics (Input)](https://docs.fluentbit.io/manual/2.0/pipeline/inputs/windows-exporter-metrics/)
       - CPU: don't compare float values directly (#6568)
-   - [Wasm (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/wasm/)
+   - [Wasm (Filter)](https://docs.fluentbit.io/manual/2.0/pipeline/filters/wasm/)
       - Fix error message
       - Use calloc to initialize value
-   - [Throttle (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/throttle/)
+   - [Throttle (Filter)](https://docs.fluentbit.io/manual/2.0/pipeline/filters/throttle/)
       - Fix print_status being partially uninitialized (#6500)
-   - [UDP (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/udp/)
+   - UDP (Output
       - New output plugin added (#6450)
-   - [Opensearch (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch/)
+   - [Opensearch (Output)](https://docs.fluentbit.io/manual/2.0/pipeline/outputs/opensearch/)
       - Fix '(null)' index when using record accessor and id_key/generate_id. (#6543)
-   - [S3 (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/s3/)
+   - [S3 (Output)](https://docs.fluentbit.io/manual/2.0/pipeline/outputs/s3/)
       - Always use sync io mode (#6574)
       - Add store_dir_limit_size to limit s3 disk usage
-   - [TCP (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/tcp/)
+   - [TCP (Output)](https://docs.fluentbit.io/manual/2.0/pipeline/outputs/tcp/)
       - New 'raw_message_key' option
-   - [Kafka (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/kafka/)
+   - [Kafka (Output)](https://docs.fluentbit.io/manual/2.0/pipeline/outputs/kafka/)
       - Fix segmentation fault issue while produce_message
-   - [Opentelemetry (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/opentelemetry/)
+   - [Opentelemetry (Output)](https://docs.fluentbit.io/manual/2.0/pipeline/outputs/opentelemetry/)
       - Move variables to heap and sanitize batch size
       - Make log records batch size to configurable
-   - [Prometheus_Exporter (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/prometheus_exporter/)
+   - [Prometheus Exporter (Output)](https://docs.fluentbit.io/manual/2.0/pipeline/outputs/prometheus-exporter/)
       - Add content-type (#6554) (#6572)
-   - [Cloudwatch_Logs (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch_logs/)
+   - [Cloudwatch Logs (Output)](https://docs.fluentbit.io/manual/2.0/pipeline/outputs/cloudwatch/)
       - AWS client extra_user_agent is sds string
 
 {{< contributor-list >}}
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 - [Eduardo Silva](https://github.com/edsiper)
 - [Wesley Pettit](https://github.com/PettitWesley)
@@ -112,7 +112,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Github: [http://github.com/fluent/fluent-bit](https://github.com/fluent/fluent-bit)
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)

--- a/content/announcements/v2.0/v2.0.8.md
+++ b/content/announcements/v2.0/v2.0.8.md
@@ -1,6 +1,6 @@
 ---
 title: 'v2.0.8'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
 url: "/announcements/v2.0.8/"
 release_date: 2022-12-23
 publishdate: 2022-12-23
@@ -49,7 +49,7 @@ Fluent Bit v2.0 is the start of the new stable series of the project. During the
  - Plugins
    - Storage Backlog (Input)
       - Added code to discard irrecoverable chunks if desired
-   - [Windows_Exporter_Metrics (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/windows_exporter_metrics/)
+   - [Windows Exporter Metrics (Input)](https://docs.fluentbit.io/manual/2.0/pipeline/inputs/windows-exporter-metrics/)
       - Implement allowing regex on net metrics to filter by name of nic
       - Implement allow/deny regex for logical_disks
       - Implement WMI system metrics
@@ -58,15 +58,15 @@ Fluent Bit v2.0 is the start of the new stable series of the project. During the
       - Proceed perflib operation at least 1 perf_object is existing
       - Provide network interface metrics
       - Implement OS metrics
-   - [Stackdriver (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver/)
+   - [Stackdriver (Output)](https://docs.fluentbit.io/manual/2.0/pipeline/outputs/stackdriver/)
       - Add Cache token expiration and use it when using cached tokens (#6453)
-   - [Kafka (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/kafka/)
+   - [Kafka (Output)](https://docs.fluentbit.io/manual/2.0/pipeline/outputs/kafka/)
       - Support `iso8601_ns` format
 
 {{< contributor-list >}}
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 - [David Korczynski](https://github.com/DavidKorczynski)
 - [Takahiro Yamashita](https://github.com/nokute78)
@@ -79,7 +79,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Github: [http://github.com/fluent/fluent-bit](https://github.com/fluent/fluent-bit)
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)

--- a/content/announcements/v2.0/v2.0.9.md
+++ b/content/announcements/v2.0/v2.0.9.md
@@ -1,6 +1,6 @@
 ---
 title: 'v2.0.9'
-description: 'We provide the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
+description: 'We provide the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
 url: "/announcements/v2.0.9/"
 release_date: 2023-02-06
 publishdate: 2023-02-06
@@ -30,7 +30,7 @@ Fluent Bit v2.0 is the start of the new stable series of the project. During the
  - Core
    - bin: fix handling of buffer for text helper
    - tls: openssl: add SSL_ERROR_SYSCALL case (#6489)
-   - stream: fixed an condition that caused concurrency issues
+   - stream: fixed a condition that caused concurrency issues
    - parser: logfmt: optionally reject messages that have keys without values
    - parser: fix overflow
    - aws: util: extra_user_agent is always type flb_sds_t
@@ -48,40 +48,40 @@ Fluent Bit v2.0 is the start of the new stable series of the project. During the
    - cfl: upgrade to v0.2.0
 
  - Plugins
-   - [Syslog (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/syslog/)
+   - [Syslog (Input)](https://docs.fluentbit.io/manual/2.0/pipeline/inputs/syslog/)
       - Added an option `raw_message_key` to append the raw message to the log record under a specific key.
-   - [Tail (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/tail/)
+   - [Tail (Input)](https://docs.fluentbit.io/manual/2.0/pipeline/inputs/tail/)
       - Remove extra fstat() syscall and remove unused function
-   - [Windows_Exporter_Metrics (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/windows_exporter_metrics/)
+   - [Windows Exporter Metrics (Input)](https://docs.fluentbit.io/manual/2.0/pipeline/inputs/windows-exporter-metrics/)
       - CPU: don't compare float values directly (#6568)
-   - [Wasm (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/wasm/)
+   - [Wasm (Filter)](https://docs.fluentbit.io/manual/2.0/pipeline/filters/wasm/)
       - Fix error message
       - Use calloc to initialize value
-   - [Throttle (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/throttle/)
+   - [Throttle (Filter)](https://docs.fluentbit.io/manual/2.0/pipeline/filters/throttle/)
       - Fix print_status being partially uninitialized (#6500)
-   - [UDP (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/udp/)
+   - UDP (Output)
       - Add new UDP output plugin (#6450)
-   - [Opensearch (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch/)
+   - [Opensearch (Output)](https://docs.fluentbit.io/manual/2.0/pipeline/outputs/opensearch/)
       - Fix '(null)' index when using record accessor and id_key/generate_id. (#6543)
-   - [S3 (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/s3/)
+   - [S3 (Output)](https://docs.fluentbit.io/manual/2.0/pipeline/outputs/s3/)
       - Always use sync io mode (#6574)
       - Add `store_dir_limit_size` option to limit s3 disk usage
-   - [TCP (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/tcp/)
+   - [TCP (Output)](https://docs.fluentbit.io/manual/2.0/pipeline/outputs/tcp/)
       - Add new `raw_message_key` option
-   - [Kafka (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/kafka/)
+   - [Kafka (Output)](https://docs.fluentbit.io/manual/2.0/pipeline/outputs/kafka/)
       - Fix segmentation fault issue while produce_message
-   - [Opentelemetry (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/opentelemetry/)
+   - [Opentelemetry (Output)](https://docs.fluentbit.io/manual/2.0/pipeline/outputs/opentelemetry/)
       - Move variables to heap and sanitize batch size
       - Make log records batch size to configurable
-   - [Prometheus_Exporter (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/prometheus_exporter/)
+   - [Prometheus Exporter (Output)](https://docs.fluentbit.io/manual/2.0/pipeline/outputs/prometheus-exporter/)
       - Add content-type header (#6554) (#6572)
-   - [Cloudwatch_Logs (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch_logs/)
+   - [Cloudwatch Logs (Output)](https://docs.fluentbit.io/manual/2.0/pipeline/outputs/cloudwatch/)
       - Aws client extra_user_agent is sds string
 
 {{< contributor-list >}}
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 - [Eduardo Silva](https://github.com/edsiper)
 - [Wesley Pettit](https://github.com/PettitWesley)
@@ -106,7 +106,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Github: [http://github.com/fluent/fluent-bit](https://github.com/fluent/fluent-bit)
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)

--- a/content/announcements/v2.1/v2.1.0.md
+++ b/content/announcements/v2.1/v2.1.0.md
@@ -17,7 +17,7 @@ latestVer: true
 
 For people upgrading from previous versions you **must read** the Upgrading Notes section of our documentation:
 
-[https://docs.fluentbit.io/manual/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
+[https://docs.fluentbit.io/manual/2.1/installation/upgrade_notes](https://docs.fluentbit.io/manual/2.1/installation/upgrade_notes)
 
 #### Introduction
 
@@ -58,13 +58,13 @@ In this latest release we introduced metadata support for Logs, providing users 
 {{< contributor-list >}}
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 {{< /contributor-list >}}
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Github: [http://github.com/fluent/fluent-bit](https://github.com/fluent/fluent-bit)
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)

--- a/content/announcements/v2.1/v2.1.1.md
+++ b/content/announcements/v2.1/v2.1.1.md
@@ -1,6 +1,6 @@
 ---
 title: 'v2.1.1'
-description: 'We provides the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
+description: 'We provides the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
 url: "/announcements/v2.1.1/"
 release_date: 2023-04-20
 publishdate: 2023-04-20
@@ -17,7 +17,7 @@ latestVer: true
 
 For people upgrading from previous versions you **must read** the Upgrading Notes section of our documentation:
 
-[https://docs.fluentbit.io/manual/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
+[https://docs.fluentbit.io/manual/2.1/installation/upgrade_notes](https://docs.fluentbit.io/manual/2.1/installation/upgrade_notes)
 
 ---
 > __Apology__ for missing Podman plugin in Fluent Bit v2.1.0. It has been added to the latest version. We apologize for any inconvenience caused. Please upgrade to enjoy the enhanced functionality.
@@ -62,13 +62,13 @@ In this latest release we introduced metadata support for Logs, providing users 
 {{< contributor-list >}}
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 {{< /contributor-list >}}
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Github: [http://github.com/fluent/fluent-bit](https://github.com/fluent/fluent-bit)
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)

--- a/content/announcements/v2.1/v2.1.10.md
+++ b/content/announcements/v2.1/v2.1.10.md
@@ -1,6 +1,6 @@
 ---
 title: 'v2.1.10'
-description: 'We provide the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
+description: 'We provide the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
 url: "/announcements/v2.1.10/"
 release_date: 2023-09-28
 publishdate: 2023-09-28
@@ -49,7 +49,7 @@ Fluent Bit v2.1 is the start of the new stable series of the project. During the
     - monkey: upgrade to v1.7.2 (#7951)
 
  - Connectors / Plugins
-    - [Oracle_Log_Analytics (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/oracle_log_analytics/)
+    - [Oracle_Log_Analytics (Output)](https://docs.fluentbit.io/manual/2.1/pipeline/outputs/oracle-log-analytics/)
       - Add new Oracle Log Analytics connector (#7830)
     - Calyptia_Fleet (Input)
       - Add readlink equivalent for Windows.
@@ -57,32 +57,32 @@ Fluent Bit v2.1 is the start of the new stable series of the project. During the
       - Use generateconsolectrlevent on win32 to execute reload.
       - Reenable fleet on windows.
       - Improve configuration reloading. (#7925)
-   - [Systemd (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/systemd/)
+   - [Systemd (Input)](https://docs.fluentbit.io/manual/2.1/pipeline/inputs/systemd/)
       - Fix missing initialization to track `last_tag` (#7247)
-   - [Lua (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/lua/)
+   - [Lua (Filter)](https://docs.fluentbit.io/manual/2.1/pipeline/filters/lua/)
       - Add new option `enable_flb_null` to deal with NULL values.
-   - [Log_To_Metrics (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/log_to_metrics/)
+   - [Log To Metrics (Filter)](https://docs.fluentbit.io/manual/2.1/pipeline/filters/log_to_metrics/)
       - Add new option `add_label` to add label to generated metrics (#7739)
-   - [Azure_Logs_Ingestion (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/azure_logs_ingestion/)
+   - [Azure Logs Ingestion API(Output)](https://docs.fluentbit.io/manual/2.1/pipeline/outputs/azure_logs_ingestion/)
       - Fix null dereference (#7624)
-   - [Logdna (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/logdna/)
+   - [Logdna (Output)](https://docs.fluentbit.io/manual/2.1/pipeline/outputs/logdna/)
       - Remove unused store (#7629)
-   - [HTTP (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/http/)
+   - [HTTP (Output)](https://docs.fluentbit.io/manual/2.1/pipeline/outputs/http/)
       - Fix bug where post_all_requests() always returns a value less than 0
-   - [Forward (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/forward/)
+   - [Forward (Output)](https://docs.fluentbit.io/manual/2.1/pipeline/outputs/forward/)
       - Add new advanced property 'add_option' to allow to send custom options in the Forward protocol (advance users only).
-   - [Loki (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/loki/)
+   - [Loki (Output)](https://docs.fluentbit.io/manual/2.1/pipeline/outputs/loki/)
       - Add GZIP compression support through the `compress` option (#7949)
-   - [Azure (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/azure/)
+   - [Azure Log Analytics (Output)](https://docs.fluentbit.io/manual/2.1/pipeline/outputs/azure/)
       - Add table prefix support for Azure Log Analytics connector (#7663)
-   - [Elasticsearch (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/es/)
+   - [Elasticsearch (Output)](https://docs.fluentbit.io/manual/2.1/pipeline/outputs/elasticsearch/)
       - Check if host contains port number
 
 {{< contributor-list >}}
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 - [Aditya Bharadwaj](https://github.com/adiforluls)
 - [Leonardo Alminana](https://github.com/leonardo-albertovich)
@@ -101,7 +101,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Github: [http://github.com/fluent/fluent-bit](https://github.com/fluent/fluent-bit)
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)

--- a/content/announcements/v2.1/v2.1.2.md
+++ b/content/announcements/v2.1/v2.1.2.md
@@ -1,6 +1,6 @@
 ---
 title: 'v2.1.2'
-description: 'We provide the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
+description: 'We provide the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
 url: "/announcements/v2.1.2/"
 release_date: 2023-04-26
 publishdate: 2023-04-26
@@ -33,19 +33,19 @@ Fluent Bit v2.1 is the start of the new stable series of the project. During the
   - CFL: upgrade to v0.2.3
 
  - Plugins
-   - [Opentelemetry (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/opentelemetry/)
+   - [Opentelemetry (Input)](https://docs.fluentbit.io/manual/2.1/pipeline/inputs/opentelemetry/)
       - Fix warning at build time
-   - [Forward (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/forward/)
+   - [Forward (Input)](https://docs.fluentbit.io/manual/2.1/pipeline/inputs/forward/)
       - Allow to override events tag with 'tag' property
-   - [Podman_Metrics (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/podman_metrics/)
+   - [Podman Metrics (Input)](https://docs.fluentbit.io/manual/2.1/pipeline/inputs/podman-metrics/)
       - Fixed unit tests on cgroupsv2
-   - [Forward (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/forward/)
+   - [Forward (Output)](https://docs.fluentbit.io/manual/2.1/pipeline/outputs/forward/)
       - Added code to drop metadata by default
 
 {{< contributor-list >}}
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 
 - [Eduardo Silva](https://github.com/edsiper)
@@ -61,7 +61,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Github: [http://github.com/fluent/fluent-bit](https://github.com/fluent/fluent-bit)
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)

--- a/content/announcements/v2.1/v2.1.3.md
+++ b/content/announcements/v2.1/v2.1.3.md
@@ -1,6 +1,6 @@
 ---
 title: 'v2.1.3'
-description: 'We provide the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
+description: 'We provide the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
 url: "/announcements/v2.1.3/"
 release_date: 2023-05-18
 publishdate: 2023-05-18
@@ -42,57 +42,57 @@ Fluent Bit v2.1 is the start of the new stable series of the project. During the
    - ctraces: upgrade to v0.3.1
 
  - Plugins
-   - [Otel (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/otel/)
+   - [OpenTelemetry (Input)](https://docs.fluentbit.io/manual/2.1/pipeline/inputs/opentelemetry/)
       - Do not send content-length at 204
-   - [Windows_Exporter_Metrics (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/windows_exporter_metrics/)
+   - [Windows Exporter Metrics (Input)](https://docs.fluentbit.io/manual/2.1/pipeline/inputs/windows-exporter-metrics/)
       - Improve value type conversion
-   - [Http (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/http/)
+   - [Http (Input)](https://docs.fluentbit.io/manual/2.1/pipeline/inputs/http/)
       - Fix parser memory reinitialization
       - Do not send content-length at 204
-   - [Winevtlog (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/winevtlog/)
+   - [Winevtlog (Input)](https://docs.fluentbit.io/manual/2.1/pipeline/inputs/windows-event-log-winevtlog/)
       - Log event encoder in default case
       - Restore the previous behavior of packing string inserts
       - Properly pass the log encoder arg
-   - [Kafka (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/kafka/)
+   - [Kafka (Input)](https://docs.fluentbit.io/manual/2.1/pipeline/inputs/kafka/)
       - Updated the plugin to use the log event abstraction layer
-   - [Syslog (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/syslog/)
+   - [Syslog (Input)](https://docs.fluentbit.io/manual/2.1/pipeline/inputs/syslog/)
       - Enable in_syslog plugin on windows
-   - [Node_Exporter_Metrics (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/node_exporter_metrics/)
+   - [Node Exporter Metrics (Input)](https://docs.fluentbit.io/manual/2.1/pipeline/inputs/node-exporter-metrics/)
       - Made diskstats ignore pattern configurable
       - Made filesystem ignore patterns configurable
       - Added a systemd metrics collector (#7319)
-   - [Elasticsearch (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/elasticsearch/)
+   - [Elasticsearch (Input)](https://docs.fluentbit.io/manual/2.1/pipeline/inputs/elasticsearch/)
       - Refer the plugin provided tag
-   - [Podman_Metrics (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/podman_metrics/)
+   - [Podman Metrics (Input)](https://docs.fluentbit.io/manual/2.1/pipeline/inputs/podman-metrics/)
       - Added image label
-   - [Geoip2 (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/geoip2/)
+   - [Geoip2 (Filter)](https://docs.fluentbit.io/manual/2.1/pipeline/filters/geoip2/)
       - Properly  handle the end of chunk data condition
-   - [Lua (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/lua/)
+   - [Lua (Filter)](https://docs.fluentbit.io/manual/2.1/pipeline/filters/lua/)
       - Fix buffer size calculation
-   - [Rewrite_Tag (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/rewrite_tag/)
+   - [Rewrite Tag (Filter)](https://docs.fluentbit.io/manual/2.1/pipeline/filters/rewrite-tag/)
       - Emit using decoder parameters
-   - [Parser (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/parser/)
+   - [Parser (Filter)](https://docs.fluentbit.io/manual/2.1/pipeline/filters/parser/)
       - Fix timestamp and metadata to be properly copied (#7293)
-   - [Modify (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/modify/)
+   - [Modify (Filter)](https://docs.fluentbit.io/manual/2.1/pipeline/filters/modify/)
       - Fix clean up process
    - [Opensearch (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch/)
       - Add support for gzip compression
-   - [Prometheus_Remote_Write (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/prometheus_remote_write/)
+   - [Prometheus Remote Write (Output)](https://docs.fluentbit.io/manual/2.1/pipeline/outputs/prometheus-remote-write/)
       - Added missing header inclusion
       - Added configurable compression method
-   - [Bigquery (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/bigquery/)
+   - [Bigquery (Output)](https://docs.fluentbit.io/manual/2.1/pipeline/outputs/bigquery/)
       - Initialize sig_len
-   - [Opentelemetry (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/opentelemetry/)
+   - [Opentelemetry (Output)](https://docs.fluentbit.io/manual/2.1/pipeline/outputs/opentelemetry/)
       - Fixed ctraces decoder error handling
-   - [Stackdriver (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver/)
+   - [Stackdriver (Output)](https://docs.fluentbit.io/manual/2.1/pipeline/outputs/stackdriver/)
       - Process spanid special field
-   - [Vivo_Exporter (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/vivo_exporter/)
+   - [Vivo Exporter (Output)](https://docs.fluentbit.io/manual/2.1/pipeline/outputs/vivo-exporter/)
       - Updated the code to use the log event decoder (#7302)
 
 {{< contributor-list >}}
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 - [Leonardo Alminana](https://github.com/leonardo-albertovich)
 - Markus Meyer
@@ -115,7 +115,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Github: [http://github.com/fluent/fluent-bit](https://github.com/fluent/fluent-bit)
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)

--- a/content/announcements/v2.1/v2.1.5.md
+++ b/content/announcements/v2.1/v2.1.5.md
@@ -1,6 +1,6 @@
 ---
 title: 'v2.1.5'
-description: 'We provide the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
+description: 'We provide the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
 url: "/announcements/v2.1.5/"
 release_date: 2023-06-16
 publishdate: 2023-06-16
@@ -40,35 +40,35 @@ Fluent Bit v2.1 is the start of the new stable series of the project. During the
    - cmetrics: upgrade to v0.6.2
 
  - Plugins
-   - [Kubernetes_Events (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/kubernetes_events/)
+   - [Kubernetes Events (Input)](https://docs.fluentbit.io/manual/2.1/pipeline/inputs/kubernetes-events/)
       - Fix error when lasttimestamp is missing from an item.
       - New input plugin to retrieve kubernetes events (#7494)
-   - [Windows_Exporter_Metrics (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/windows_exporter_metrics/)
+   - [Windows Exporter Metrics (Input)](https://docs.fluentbit.io/manual/2.1/pipeline/inputs/windows-exporter-metrics/)
       - Fix wrong metrics type of free megabytes
-   - [Node_Exporter_Metrics (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/node_exporter_metrics/)
+   - [Node Exporter Metrics (Input)](https://docs.fluentbit.io/manual/2.1/pipeline/inputs/node-exporter-metrics/)
       - Update the timestamp for metrics of systemd version
       - Update systemd gauge metrics on each interval
       - Textfile: plug unhandled null case
-   - [Emitter (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/emitter/)
+   - Emitter (Input)
       - Remove unused variable
-   - [Exec (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/exec/)
+   - [Exec (Input)](https://docs.fluentbit.io/manual/2.1/pipeline/inputs/exec/)
       - Exit fluent-bit after oneshot and propagate exit code (#7207)
-   - [S3 (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/s3/)
+   - [S3 (Output)](https://docs.fluentbit.io/manual/2.1/pipeline/outputs/s3/)
       - Use new flb_aws_xml_get_val
       - Fix wrong decrementing of index when uploadpart fails (#7393)
-   - [Cloudwatch_Logs (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch_logs/)
+   - [Cloudwatch Logs (Output)](https://docs.fluentbit.io/manual/2.1/pipeline/outputs/cloudwatch/)
       - Fix logic in free-ing log streams on shutdown (#7159)
-   - [Azure_Logs_Ingestion (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/azure_logs_ingestion/)
+   - [Azure Logs Ingestion API (Output)](https://docs.fluentbit.io/manual/2.1/pipeline/outputs/azure_logs_ingestion/)
       - Implementing azure logs ingestion (with dcr, dce) output plugin (#7155)
-   - [Prometheus_Remote_Write (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/prometheus_remote_write/)
+   - [Prometheus Remote Write (Output)](https://docs.fluentbit.io/manual/2.1/pipeline/outputs/prometheus-remote-write/)
       - Handle 400 status as error immediately
-   - [Stackdriver (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver/)
+   - [Stackdriver (Output)](https://docs.fluentbit.io/manual/2.1/pipeline/outputs/stackdriver/)
       - Process tracesampled special field
 
 {{< contributor-list >}}
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 - [Wesley Pettit](https://github.com/PettitWesley)
 - [Eduardo Silva](https://github.com/edsiper)
@@ -87,7 +87,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Github: [http://github.com/fluent/fluent-bit](https://github.com/fluent/fluent-bit)
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)

--- a/content/announcements/v2.1/v2.1.6.md
+++ b/content/announcements/v2.1/v2.1.6.md
@@ -1,6 +1,6 @@
 ---
 title: 'v2.1.6'
-description: 'We provide the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
+description: 'We provide the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
 url: "/announcements/v2.1.6/"
 release_date: 2023-06-16
 publishdate: 2023-06-16
@@ -31,7 +31,7 @@ Fluent Bit v2.1 is the start of the new stable series of the project. During the
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 - [Eduardo Silva](https://github.com/edsiper)
 - [Celalettin Calis](https://github.com/celalettin1286)
@@ -40,7 +40,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Github: [http://github.com/fluent/fluent-bit](https://github.com/fluent/fluent-bit)
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)

--- a/content/announcements/v2.1/v2.1.7.md
+++ b/content/announcements/v2.1/v2.1.7.md
@@ -1,6 +1,6 @@
 ---
 title: 'v2.1.7'
-description: 'We provide the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
+description: 'We provide the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
 url: "/announcements/v2.1.7/"
 release_date: 2023-07-13
 publishdate: 2023-07-13
@@ -38,49 +38,49 @@ Fluent Bit v2.1 is the start of the new stable series of the project. During the
    - wamr: Upgrade the bundled WAMR version to 1.2.2
 
  - Plugins
-   - [Kubernetes_Filter (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/kubernetes_filter/)
+   - Kubernetes_Filter (Input)
       - Fix leak on exception
-   - [Windows_Exporter_Metrics (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/windows_exporter_metrics/)
+   - [Windows Exporter Metrics (Input)](https://docs.fluentbit.io/manual/2.1/pipeline/inputs/windows-exporter-metrics/)
       - Handle `we.service.include` and `we.service.exclude` options to construct where clause
       - Prevent to operate service metrics when terminating
       - Display errored property name
-      - Implement windows service metrics
-   - [Splunk (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/splunk/)
+      - Implement Windows service metrics
+   - [Splunk (Input)](https://docs.fluentbit.io/manual/2.1/pipeline/inputs/splunk/)
       - Implement new Splunk HEC input plugin (#7349)
-   - [Node_Exporter_Metrics (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/node_exporter_metrics/)
+   - [Node Exporter Metrics (Input)](https://docs.fluentbit.io/manual/2.1/pipeline/inputs/node-exporter-metrics/)
       - Update metrics value only if succeeded
       - Handle missing throttle metrics case such as vm
-   - [Elasticsearch (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/elasticsearch/)
+   - [Elasticsearch (Input)](https://docs.fluentbit.io/manual/2.1/pipeline/inputs/elasticsearch/)
       - Provide version parameter for configurable server version (#7579)
-   - [Podman_Metrics (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/podman_metrics/)
+   - [Podman Metrics (Input)](https://docs.fluentbit.io/manual/2.1/pipeline/inputs/podman-metrics/)
       - Fixed reading undefined PID
-   - [Kubernetes_Events (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/kubernetes_events/)
+   - [Kubernetes Events (Input)](https://docs.fluentbit.io/manual/2.1/pipeline/inputs/kubernetes-events/)
       - Call destructor when init failed
       - Remove unnecessary type check
       - Allow setting `kube_token_file` as empty for use with kubectl proxy.
       - Allow listening to a single namespace with the 'namespace' parameter.
       - Increase lookup interval to 500 milliseconds.
-   - [Exec_Wasi (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/exec_wasi/)
+   - [Exec Wasi (Input)](https://docs.fluentbit.io/manual/2.1/pipeline/inputs/exec-wasi/)
       - Add error message
       - Fix possible null deref
-   - [Rewrite_Tag (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/rewrite_tag/)
+   - [Rewrite Tag (Filter)](https://docs.fluentbit.io/manual/2.1/pipeline/filters/rewrite-tag/)
       - Fix potential null dereference
-   - [Stackdriver (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver/)
+   - [Stackdriver (Output)](https://docs.fluentbit.io/manual/2.1/pipeline/outputs/stackdriver/)
       - Support gzip compression with the new `compress` option (#7101)
-   - [Stdout (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/stdout/)
+   - [Standard Output (Output)](https://docs.fluentbit.io/manual/2.1/pipeline/outputs/standard-output/)
       - Modify to check decoding result
-   - [Gelf (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/gelf/)
+   - [Gelf (Output)](https://docs.fluentbit.io/manual/2.1/pipeline/outputs/gelf/)
       - Fix releasing function handling (#7640)
-   - [Chronicle (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/chronicle/)
+   - [Chronicle (Output)](https://docs.fluentbit.io/manual/2.1/pipeline/outputs/chronicle/)
       - Implement new Google Chronicle output plugin (#7232)
-   - [Syslog (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/syslog/)
+   - [Syslog (Output)](https://docs.fluentbit.io/manual/2.1/pipeline/outputs/syslog/)
       - Check error after flb_log_event_decoder_next (#7639)
 
 {{< contributor-list >}}
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 - [Phillip Whelan](https://github.com/pwhelan)
 - [Leonardo Alminana](https://github.com/leonardo-albertovich)
@@ -97,7 +97,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Github: [http://github.com/fluent/fluent-bit](https://github.com/fluent/fluent-bit)
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)

--- a/content/announcements/v2.1/v2.1.8.md
+++ b/content/announcements/v2.1/v2.1.8.md
@@ -1,6 +1,6 @@
 ---
 title: 'v2.1.8'
-description: 'We provide the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
+description: 'We provide the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
 url: "/announcements/v2.1.8/"
 release_date: 2023-07-13
 publishdate: 2023-07-13
@@ -48,31 +48,31 @@ Fluent Bit v2.1 is the start of the new stable series of the project. During the
    - monkey: upgrade to v1.7.1
 
  - Plugins
-   - [HTTP (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/http/)
+   - [HTTP (Input)](https://docs.fluentbit.io/manual/2.1/pipeline/inputs/http/)
       - Add support for form/url_encoded payloads. (#6960)
-   - [Tail (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/tail/)
+   - [Tail (Input)](https://docs.fluentbit.io/manual/2.1/pipeline/inputs/tail/)
       - Fix `ignore_older` description.
       - Don't append records if sl_log_event_encoder buffer is 0 (#7723)
-   - [Collectd (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/collectd/)
+   - [Collectd (Input)](https://docs.fluentbit.io/manual/2.1/pipeline/inputs/collectd/)
       - Add missing flb_input_net_server flag.
-   - [Kafka (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/kafka/)
+   - [Kafka (Input)](https://docs.fluentbit.io/manual/2.1/pipeline/inputs/kafka/)
       - Implement new `format` config option.
       - Fix json packing
-   - [Calyptia_Fleet (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/calyptia_fleet/)
+   - Calyptia_Fleet (Input)
       - Keep casing consistent in the generated configuration file.
       - Maintain fleet_name parameter across reloads.
       - Fix use after free and non-null terminated string.
       - Add `fleet_name` parameter.
-   - [Syslog (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/syslog/)
+   - [Syslog (Input)](https://docs.fluentbit.io/manual/2.1/pipeline/inputs/syslog/)
       - Provide appending source address parameter (#7651)
-   - [Statsd (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/statsd/)
+   - [Statsd (Output)](https://docs.fluentbit.io/manual/2.1/pipeline/outputs/statsd/)
       - Add missing `flb_input_net_server` flag.
 
 {{< contributor-list >}}
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 - [Takahiro Yamashita](https://github.com/nokute78)
 - [Hiroshi Hatake](https://github.com/cosmo0920)
@@ -91,7 +91,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Github: [http://github.com/fluent/fluent-bit](https://github.com/fluent/fluent-bit)
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)

--- a/content/announcements/v2.1/v2.1.9.md
+++ b/content/announcements/v2.1/v2.1.9.md
@@ -1,6 +1,6 @@
 ---
 title: 'v2.1.9'
-description: 'We provide the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
+description: 'We provide the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
 url: "/announcements/v2.1.9/"
 release_date: 2023-09-05
 publishdate: 2023-09-05
@@ -46,42 +46,42 @@ Fluent Bit v2.1 is the start of the new stable series of the project. During the
    - c-ares: upgrade to v1.19.1
 
  - Plugins
-   - [Nginx_Exporter_Metrics (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/nginx_exporter_metrics/)
+   - [NGINX Exporter Metrics (Input)](https://docs.fluentbit.io/manual/2.1/pipeline/inputs/nginx/)
       - Add missing release function
-   - [Udp (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/udp/)
+   - [Udp (Input)](https://docs.fluentbit.io/manual/2.1/pipeline/inputs/udp/)
       - Add a capability to inject source ip (#7673)
-   - [Windows_Exporter_Metrics (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/windows_exporter_metrics/)
+   - [Windows Exporter Metrics (Input)](https://docs.fluentbit.io/manual/2.1/pipeline/inputs/windows-exporter-metrics/)
       - Implement wmi based process metrics (#7860)
       - Implement wmi based memory and paging_file metrics (#7817)
-   - [Prometheus_Scrape (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/prometheus_scrape/)
+   - [Prometheus Scrape Metrics (Input)](https://docs.fluentbit.io/manual/2.1/pipeline/inputs/prometheus-scrape-metrics/)
       - Added authorization support (#7785)
-   - [Lib (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/lib/)
+   - Lib (Input)
       - Fix error handling after flb_log_event_decoder_next
-   - [Winevtlog (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/winevtlog/)
+   - [Winevtlog (Input)](https://docs.fluentbit.io/manual/2.1/pipeline/inputs/windows-event-log-winevtlog/)
       - Support xml query parameter for filtering events
-   - [MQTT (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/mqtt/)
+   - [MQTT (Input)](https://docs.fluentbit.io/manual/2.1/pipeline/inputs/mqtt/)
       - Support payload_key
-   - [Event_Test (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/event_test/)
+   - Event_Test (Input)
       - Add +1 for acceptable time elapse
-   - [Calyptia_Fleet (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/calyptia_fleet/)
+   - Calyptia_Fleet (Input)
       - Use the machine_id in the fleet configuration directory.
-   - [Tail (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/tail/)
+   - [Tail (Input)](https://docs.fluentbit.io/manual/2.1/pipeline/inputs/tail/)
       - Removed ignore_older enforcement on files that are being ingested
       - Refactored the progress check to signal the event based collector
       - Fix event based pending data ingestion collector limits
-   - [Node_Exporter_Metrics (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/node_exporter_metrics/)
+   - [Node Exporter Metrics (Input)](https://docs.fluentbit.io/manual/2.1/pipeline/inputs/node-exporter-metrics/)
       - Fix registering callback for Systemd
-   - [Exec_Wasi (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/exec_wasi/)
+   - [Exec_Wasi (Input)](https://docs.fluentbit.io/manual/2.1/pipeline/inputs/exec-wasi/)
       - Fix possible file descriptor leak
-   - [S3 (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/s3/)
+   - [S3 (Output)](https://docs.fluentbit.io/manual/2.1/pipeline/outputs/s3/)
       - Fix file descriptor leak
       - Fix potential file descriptor leak
-   - [Stackdriver (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver/)
+   - [Stackdriver (Output)](https://docs.fluentbit.io/manual/2.1/pipeline/outputs/stackdriver/)
       - Change default workers to 1
       - Fix access token caching
-   - [Kinesis_Streams (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/kinesis_streams/)
+   - [Kinesis_Streams (Output)](https://docs.fluentbit.io/manual/2.1/pipeline/outputs/kinesis/)
       - Remove dead stores
-   - [Splunk (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/splunk/)
+   - [Splunk (Output)](https://docs.fluentbit.io/manual/2.1/pipeline/outputs/splunk/)
       - Release flb_ra_translate result buffer on failure
    - Calyptia (Custom)
       - pass the fleet_id parameter and label to out_calyptia.
@@ -93,7 +93,7 @@ Fluent Bit v2.1 is the start of the new stable series of the project. During the
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 
 - [Phillip Whelan](https://github.com/pwhelan)
@@ -115,7 +115,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Github: [http://github.com/fluent/fluent-bit](https://github.com/fluent/fluent-bit)
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)

--- a/content/announcements/v2.2/v2.2.0.md
+++ b/content/announcements/v2.2/v2.2.0.md
@@ -17,7 +17,7 @@ latestVer: true
 
 For people upgrading from previous versions you **must read** the Upgrading Notes section of our documentation:
 
-[https://docs.fluentbit.io/manual/installation/upgrade_notes](https://docs.fluentbit.io/manual/installation/upgrade_notes)
+[https://docs.fluentbit.io/manual/2.2/installation/upgrade_notes](https://docs.fluentbit.io/manual/2.2/installation/upgrade_notes)
 
 #### Introduction
 
@@ -61,23 +61,23 @@ Fluent Bit v2.2 is the start of the new stable series of the project. During the
    - chunk_trace: add reporting for outputs.
    - chunk_trace: use a separate thread for trace pipelines.
    - utils: add code for getting the machineID on macOS. (#8096)
-   - utils: add code to get the machine-id on windows machines. (#7970)
+   - utils: add code to get the machine-id on Windows machines. (#7970)
 
  - Libs
    - cmetrics: upgrade to v0.6.4
 
  - Plugins
-   - [Fluentbit_Metrics (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/fluentbit_metrics/)
+   - [Fluentbit Metrics (Input)](https://docs.fluentbit.io/manual/2.2/pipeline/inputs/fluentbit-metrics/)
       - Add missing release function on init
-   - [Process_Exporter_Metrics (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/process_exporter_metrics/)
+   - [Process Exporter Metrics (Input)](https://docs.fluentbit.io/manual/2.2/pipeline/inputs/process-exporter-metrics/)
       - Implement process exporter metrics (#7943)
-   - [Dummy (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/dummy/)
+   - [Dummy (Input)](https://docs.fluentbit.io/manual/2.2/pipeline/inputs/dummy/)
       - Use interval_sec/nsec instead of time_interval.
       - Reducing tests maximum duration.
       - Add unit tests for rate and time_interval.
       - Rename time interval variables.
       - Add time_interval setting.
-   - [Calyptia_Fleet (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/calyptia_fleet/)
+   - Calyptia_Fleet (Input)
       - Get `__mkdir` to work on non-unix operating systems. (#7969)
       - Free up filenames and data during collect callback.
       - Free http client when retrieving fleet_id from fleet_name.
@@ -91,64 +91,64 @@ Fluent Bit v2.2 is the start of the new stable series of the project. During the
       - Add old file name to list of valid configuration names.
       - Remove info messsage using event_fd.
       - Remove unused event_fd configuration property.
-   - [Thermal (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/thermal/)
+   - [Thermal (Input)](https://docs.fluentbit.io/manual/2.2/pipeline/inputs/thermal/)
       - Support hwmon (#8016)
-   - [Node_Exporter_Metrics (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/node-exporter-metrics)
+   - [Node Exporter Metrics (Input)](https://docs.fluentbit.io/manual/2.2/pipeline/inputs/node-exporter-metrics)
       - Implement a more pluggable architecture for the collectors (#7944)
       - Implement nvme metrics (#8049)
       - Fix referencing wrong interval (#8019)
-      - Fix macos build (#8048)
+      - Fix macOS build (#8048)
       - Implement processes metrics (#7880)
       - Plug undefined value for netif name
       - Support diskstats metrics on macos
       - Add netdev metrics on macos
-      - Support meminfo metrics on macos
+      - Support meminfo metrics on macOS
       - Support uname metrics on macos
       - Add loadavg metrics for macos
-      - Support cpu seconds collection on macos
-      - Make buildable with skeletons on macos
-   - [Splunk (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/splunk/)
+      - Support cpu seconds collection on macOS
+      - Make buildable with skeletons on macOS
+   - [Splunk (Input)](https://docs.fluentbit.io/manual/2.2/pipeline/inputs/splunk/)
       - Ensure releasing tag_from_record after procressing it
-   - [Forward (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/forward/)
+   - [Forward (Input)](https://docs.fluentbit.io/manual/2.2/pipeline/inputs/forward/)
       - Extract a function for appending logs
       - Handle non log types of compressed events
       - Fix checking return value of cmt_decode_msgpack_create(#8000) (#8015)
-   - [Docker (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/docker/)
+   - [Docker (Input)](https://docs.fluentbit.io/manual/2.2/pipeline/inputs/docker/)
       - Implement a capability for cgroups v2
       - Add unit test and make configurable paths (mostly for testing)
-   - [Lua (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/lua/)
+   - [Lua (Filter)](https://docs.fluentbit.io/manual/2.2/pipeline/filters/lua/)
       - Add index to arraylength call
       - Provide additional script validator before running as cb_pre_run
       - Plug a memory leak on loading for an invalid lua script
-   - [Sysinfo (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/sysinfo/)
+   - [Sysinfo (Filter)](https://docs.fluentbit.io/manual/2.2/pipeline/filters/sysinfo/)
       - Add filter sysinfo plugin
-   - [Wasm (Filter)](https://docs.fluentbit.io/manual/pipeline/filters/wasm/)
+   - [Wasm (Filter)](https://docs.fluentbit.io/manual/2.2/pipeline/filters/wasm/)
       - Provide additional validator for checking existence of the file in wasm_path
-   - [Chronicle (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/chronicle/)
+   - [Chronicle (Output)](https://docs.fluentbit.io/manual/2.2/pipeline/outputs/chronicle/)
       - Remove redundant code (#8004)
-   - [Syslog (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/syslog/)
+   - [Syslog (Output)](https://docs.fluentbit.io/manual/2.2/pipeline/outputs/syslog/)
       - When using a message key, avoid prefixing raw messages
-   - [Loki (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/loki/)
+   - [Loki (Output)](https://docs.fluentbit.io/manual/2.2/pipeline/outputs/loki/)
       - Add ability to add arbitrary http headers and adjust the uri path (#7979)
       - Add new option `uri` to customize http uri endpoint
-   - [Stackdriver (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver/)
+   - [Stackdriver (Output)](https://docs.fluentbit.io/manual/2.2/pipeline/outputs/stackdriver/)
       - fix: don't overwrite ctx->client_email and ctx->private_key. (#8093)
-   - [Forward (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/forward/)
+   - [Forward (Output)](https://docs.fluentbit.io/manual/2.2/pipeline/outputs/forward/)
       - Add compressed=gzip option for non log types of events
-   - [Cloudwatch_Logs (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch_logs/)
+   - [Cloudwatch Logs (Output)](https://docs.fluentbit.io/manual/2.2/pipeline/outputs/cloudwatch/)
       - Enhance api error response readability
       - Remove sequence tokens from api calls (#7973)
 
 {{< contributor-list >}}
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 {{< /contributor-list >}}
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Github: [http://github.com/fluent/fluent-bit](https://github.com/fluent/fluent-bit)
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)

--- a/content/announcements/v2.2/v2.2.1.md
+++ b/content/announcements/v2.2/v2.2.1.md
@@ -1,6 +1,6 @@
 ---
 title: 'v2.2.1'
-description: 'We provide the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
+description: 'We provide the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
 url: "/announcements/v2.2.1/"
 release_date: 2023-12-22
 publishdate: 2023-12-22
@@ -34,7 +34,7 @@ Fluent Bit v2.1 is the start of the new stable series of the project. During the
    - engine: Extract a function for calculating capacity of chunks
    - engine: output: Add metrics for displaying the available capacity of chunks as percent
    - task: remove guard around total_events
-   - filter: update total_records outside of ifdef
+   - filter: update total_records outside ifdef
    - config_format: yaml: test: Make runnable for yaml config on Windows
    - config_format: yaml: Use \ instead of / for concatenating paths on Windows
    - input_chunk: skip overlimit check in mem mode (#8199)
@@ -53,44 +53,44 @@ Fluent Bit v2.1 is the start of the new stable series of the project. During the
    - c-ares: upgrade from v1.19.1 to v1.24.0
    
  - Plugins
-   - [Calyptia_Fleet (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/calyptia_fleet/)
+   - Calyptia_Fleet (Input)
       - Fix double free when calyptia api returns with an empty response payload.
       - Create configuration directory before the fleet header.
       - Fix warnings in error handling code for get_calyptia_file.
       - Use header with main configuration settings. (#8102)
       - Support multiple files for configurations. (#8092)
-   - [Process_Exporter_Metrics (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/process_exporter_metrics/)
+   - [Process Exporter Metrics (Input)](https://docs.fluentbit.io/manual/2.2/pipeline/inputs/process-exporter-metrics/)
       - Release str in error cases (#8163)
-   - [Winevtlog (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/winevtlog/)
+   - [Winevtlog (Input)](https://docs.fluentbit.io/manual/2.2/pipeline/inputs/windows-event-log-winevtlog/)
       - Pass correct value (#8179)
-   - [Kafka (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/kafka/)
-      - Append logs only for non zero length cases
+   - [Kafka (Input)](https://docs.fluentbit.io/manual/2.2/pipeline/inputs/kafka/)
+      - Append logs only for non-zero length cases
       - Rely on only buffer_max_size for preventing greedy consuming topics
       - Implement restrictive polling by default
       - Handle limit of buffer for fs chunks with buffer_chunk_size config parameter
       - Suspend polling when reaching mem_limit
       - Setup `fetch.max.bytes` properly
       - Register pause/resume callbacks to handle back pressure correctly
-   - [Opentelemetry (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/opentelemetry/)
+   - [Opentelemetry (Input)](https://docs.fluentbit.io/manual/2.2/pipeline/inputs/opentelemetry/)
       - Support new `tag_from_uri` property 
       - Fix memory leak
-   - [Node_Exporter_Metrics (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/node_exporter_metrics/)
+   - [Node Exporter Metrics (Input)](https://docs.fluentbit.io/manual/2.2/pipeline/inputs/node-exporter-metrics/)
       - Add support for thermal_zone. (#7522)
       - Suppress error log when nvme is not mounted in the node
-   - [Kubernetes_Events (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/kubernetes_events/)
+   - [Kubernetes Events (Input)](https://docs.fluentbit.io/manual/2.2/pipeline/inputs/kubernetes-events/)
       - Set default timestamp_key to `$lasttimestamp` (record accessor pattern)
       - Make timestamp from incoming record configurable
-   - [Stackdriver (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver/)
+   - [Stackdriver (Output)](https://docs.fluentbit.io/manual/2.2/pipeline/outputs/stackdriver/)
       - Add partialsuccess: true
       - Test_log_entry_format will output log entries to stdout
-   - [Stdout (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/stdout/)
+   - [Standard Output (Output)](https://docs.fluentbit.io/manual/2.2/pipeline/outputs/standard-output/)
       - Fix incomplete printing of traces
 
 {{< contributor-list >}}
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 - [Türkalp Burak Kayrancıoğlu](https://github.com/bkayranci)
 - [ryanohnemus](https://github.com/ryanohnemus)
@@ -110,7 +110,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Github: [http://github.com/fluent/fluent-bit](https://github.com/fluent/fluent-bit)
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)

--- a/content/announcements/v2.2/v2.2.2.md
+++ b/content/announcements/v2.2/v2.2.2.md
@@ -1,6 +1,6 @@
 ---
 title: 'v2.2.2'
-description: 'We provide the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
+description: 'We provide the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
 url: "/announcements/v2.2.2/"
 release_date: 2023-12-22
 publishdate: 2023-12-22
@@ -36,28 +36,28 @@ Fluent Bit v2.2 is the start of the new stable series of the project. During the
    - lib: monkey: upgrade to v1.7.3 (#8363)
 
  - Plugins
-   - [Dummy (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/dummy/)
+   - [Dummy (Input)](https://docs.fluentbit.io/manual/2.2/pipeline/inputs/dummy/)
       - Add `flush_on_startup` config. (#8222)
-   - [Http (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/http/)
+   - [Http (Input)](https://docs.fluentbit.io/manual/2.2/pipeline/inputs/http/)
       - Fix payload parsing and error response
-   - [Storage_Backlog (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/storage_backlog/)
+   - Storage_Backlog (Input)
       - If a chunk tag cannot be read, delete it
-   - [Calyptia_Fleet (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/calyptia_fleet/)
+   - Calyptia_Fleet (Input)
       - Release upstream conn in collect. (#8366)
-   - [Node_Exporter_Metrics (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/node_exporter_metrics/)
+   - [Node Exporter Metrics (Input)](https://docs.fluentbit.io/manual/2.2/pipeline/inputs/node-exporter-metrics/)
       - Collect metrics at startup (#8368) (#8370)
-   - [Kubernetes_Events (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/kubernetes_events/)
+   - [Kubernetes Events (Input)](https://docs.fluentbit.io/manual/2.2/pipeline/inputs/kubernetes-events/)
       - Consolidate record timestamp logic (#8323)
-   - [Stackdriver (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver/)
+   - [Stackdriver (Output)](https://docs.fluentbit.io/manual/2.2/pipeline/outputs/stackdriver/)
       - Add `project_id_key` override (#8209)
-   - [Azure_Blob (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/azure_blob/)
+   - [Azure Blob (Output)](https://docs.fluentbit.io/manual/2.2/pipeline/outputs/azure_blob/)
       - Add support for Azure blob SAS authentication (#8243)
 
 {{< contributor-list >}}
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 - [Türkalp Burak Kayrancıoğlu](https://github.com/bkayranci)
 - [ryanohnemus](https://github.com/ryanohnemus)
@@ -77,7 +77,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Github: [http://github.com/fluent/fluent-bit](https://github.com/fluent/fluent-bit)
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)

--- a/content/announcements/v2.2/v2.2.3.md
+++ b/content/announcements/v2.2/v2.2.3.md
@@ -1,6 +1,6 @@
 ---
 title: 'v2.2.3'
-description: 'We provide the means for the collection, organization and computerized retrieval of knowledgeand Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
+description: 'We provide the means for the collection, organization and computerized retrieval of knowledge and Lightweight Data Forwarder for Linux, BSD, macOS and Windows.'
 url: "/announcements/v2.2.3/"
 release_date: 2024-05-21
 publishdate: 2024-05-21
@@ -52,18 +52,18 @@ Fluent Bit v2.2 is currently is maintenance only with security fixes. This speci
       - Code style cleanup
       - Improve connection context handling
       - Remove double free of cfl_array_destroy()
-   - [Kubernetes_Events (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/kubernetes_events/)
+   - [Kubernetes Events (Input)](https://docs.fluentbit.io/manual/2.2/pipeline/inputs/kubernetes-events/)
       - Refactor time check to use struct flb_time. (#8845)
-   - [HTTP (Input)](https://docs.fluentbit.io/manual/pipeline/inputs/http/)
+   - [HTTP (Input)](https://docs.fluentbit.io/manual/2.2/pipeline/inputs/http/)
       - Adds support for content-encoding: gzip (#7667)
-   - [Forward (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/forward/)
+   - [Forward (Output)](https://docs.fluentbit.io/manual/2.2/pipeline/outputs/forward/)
       - Fix memory leak during connection loss
 
 {{< contributor-list >}}
 
 #### Contributors
 
-On every release, there are many people involved doing contributions on different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
+On every release, there are many people involved doing contributions to different areas like bug reporting, troubleshooting, documentation and coding, without these contributions from the community, the project won’t be the same and won’t be in the good shape that it is now. So THANK YOU! to everyone who takes part of this journey!
 
 - [Eduardo Silva](https://github.com/edsiper)
 - [Phillip Whelan](https://github.com/pwhelan)
@@ -77,7 +77,7 @@ On every release, there are many people involved doing contributions on differen
 
 #### Join us
 
-We want to hear about you, our community is growing and you can be part of it!, you can contact us at:
+We want to hear about you, our community is growing, and you can be part of it!, you can contact us at:
 
 * Github: [http://github.com/fluent/fluent-bit](https://github.com/fluent/fluent-bit)
 * Slack: [http://slack.fluentd.org](http://slack.fluentd.org)


### PR DESCRIPTION
Fixes for release docs plugin links for Fluent Bit v2.0 through v2.2. Part of issue #30. 