### PR TITLE
Fixed typo in versions fixed, changing 4.0.14 to 4.0.13. Fixes #11230.

### DIFF
--- a/content/posts/security-vulnerabilities-addressed-in-fluent-bit-v4.1-and-backported-to-v4.0.md
+++ b/content/posts/security-vulnerabilities-addressed-in-fluent-bit-v4.1-and-backported-to-v4.0.md
@@ -1,7 +1,7 @@
 ---
 title: "Security Vulnerabilities Addressed in Fluent Bit v4.1 and Backported to v4.0"
 date: 2025-10-28
-description: "Summary of security issues reported and remediated in Fluent Bit v4.2, v4.1.1, and v4.0.14, including path traversal, stack buffer overflow, and authentication bypass fixes."
+description: "Summary of security issues reported and remediated in Fluent Bit v4.2, v4.1.1, and v4.0.13, including path traversal, stack buffer overflow, and authentication bypass fixes."
 tags: ["fluentbit", "security", "cve", "vulnerability"]
 image: "/images/blog/1701353456-general-fluent-bit-preview-card.png"
 author: "Fluent Bit Team"
@@ -10,7 +10,7 @@ herobg: "/images/blog/1689182792-background-fluent-bit.png"
 
 **Scope:** Fluent Bit Security issues reported in [GitHub Security Advisory](https://github.com/fluent/fluent-bit/security/advisories/GHSA-r6wj-v2vm-9mjj) (restricted access)
 
-On October 23, 2025, we were notified of a few security issues present in Fluent Bit. Those security issues have been remediated in the latest versions currently available of Fluent Bit v4.2, v4.1 (4.1.1) as well as v4.0 (4.0.14). Below please find a summary of the issues and remediation.
+On October 23, 2025, we were notified of a few security issues present in Fluent Bit. Those security issues have been remediated in the latest versions currently available of Fluent Bit v4.2, v4.1 (4.1.1) as well as v4.0 (4.0.13). Below please find a summary of the issues and remediation.
 
 ---
 
@@ -34,11 +34,11 @@ On October 23, 2025, we were notified of a few security issues present in Fluent
 
 | ID | Description | Exploit Status | Remediation Status |
 |---------|-------------|----------------|-------------------|
-| CWE 193 | The issue cannot be exploited for memory corruption, data leakage, or arbitrary code execution. It may only lead to incorrect string decoding. | None reported | Bug fix - not a security issue (no CVE applicable). Remediated in version 4.1.1 and 4.0.14 |
-| CWE 187 | A remote attacker with access to input endpoints (e.g. HTTP, Splunk, Elasticsearch) could manipulate tag prefixes to inject data into unintended backends. This affects data integrity, not confidentiality or memory safety. | None reported | Security issue - CVE applicable (data integrity impact). Remediated in version 4.1.1 and 4.0.14 |
-| CWE 35 | An attacker able to control the tag value could cause Fluent Bit to write outside the configured directory path. Affects file integrity and host filesystem isolation. | None reported | Security issue - CVE applicable. Remediated in version 4.1.1 and 4.0.14 |
-| CWE 121 | A long container name from the Docker API could trigger a stack overflow. The issue is locally exploitable and may lead to denial of service (crash) or potentially arbitrary code execution. | None reported | Security issue - CVE applicable. Remediated in version 4.1.1 and 4.0.14 |
-| CWE 306 | Remote attackers could send data without credentials, bypassing authentication controls. This compromises the authenticity of ingested logs and can allow injection of forged data. | None reported | Security issue - CVE applicable. Remediated in version 4.1.1 and 4.0.14 |
+| CWE 193 | The issue cannot be exploited for memory corruption, data leakage, or arbitrary code execution. It may only lead to incorrect string decoding. | None reported | Bug fix - not a security issue (no CVE applicable). Remediated in version 4.1.1 and 4.0.13 |
+| CWE 187 | A remote attacker with access to input endpoints (e.g. HTTP, Splunk, Elasticsearch) could manipulate tag prefixes to inject data into unintended backends. This affects data integrity, not confidentiality or memory safety. | None reported | Security issue - CVE applicable (data integrity impact). Remediated in version 4.1.1 and 4.0.13 |
+| CWE 35 | An attacker able to control the tag value could cause Fluent Bit to write outside the configured directory path. Affects file integrity and host filesystem isolation. | None reported | Security issue - CVE applicable. Remediated in version 4.1.1 and 4.0.13 |
+| CWE 121 | A long container name from the Docker API could trigger a stack overflow. The issue is locally exploitable and may lead to denial of service (crash) or potentially arbitrary code execution. | None reported | Security issue - CVE applicable. Remediated in version 4.1.1 and 4.0.13 |
+| CWE 306 | Remote attackers could send data without credentials, bypassing authentication controls. This compromises the authenticity of ingested logs and can allow injection of forged data. | None reported | Security issue - CVE applicable. Remediated in version 4.1.1 and 4.0.13 |
 
 ---
 


### PR DESCRIPTION
Fixed typo in versions fixed, changing 4.0.14 to 4.0.13. Fixes <https://github.com/fluent/fluent-bit/issues/11230>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security vulnerability advisory documentation to accurately reflect the correct remediation version for all security entries, ensuring users have precise information when reviewing applicable security fixes and remediation status.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->